### PR TITLE
feat(unique): roll atomic unique enforcement across remaining engines

### DIFF
--- a/.changeset/serious-geese-bow.md
+++ b/.changeset/serious-geese-bow.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Extend atomic unique-index enforcement coverage across all engine integrations by declaring explicit unique-constraint capabilities on the remaining adapters and adding shared integration tests for duplicate create/update/batchSet behavior.
+
+Add a store-level unique guard that uses engine-backed locks and index checks to enforce unique index values consistently across create, update, batchSet, lazy writeback, and migration persistence paths.

--- a/src/engines/cassandra.ts
+++ b/src/engines/cassandra.ts
@@ -132,6 +132,10 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
   }
 
   const engine: CassandraQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       await ready;
 

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -215,6 +215,10 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
   const keyConfig = normalizeKeyConfig(options);
 
   const engine: DynamoDbQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       const item = await getDocumentItem(client, tableName, keyConfig, collection, key);
 

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -116,6 +116,10 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
   );
 
   const engine: FirestoreQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       const raw = await documentRef(documentsCollection, collection, key).get();
       const snapshot = parseDocumentSnapshot(raw, "document record");

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -131,6 +131,10 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
   const dbPromise = openDatabase(factory, databaseName);
 
   const engine: IndexedDbQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     close() {
       void dbPromise.then((db) => db.close()).catch(() => undefined);
     },

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -120,6 +120,10 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
   const ready = ensureSchema(documentsCollection, metadataCollection);
 
   const engine: MongoDbQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       await ready;
 

--- a/src/engines/mysql.ts
+++ b/src/engines/mysql.ts
@@ -82,6 +82,10 @@ export function mySqlEngine(options: MySqlEngineOptions): MySqlQueryEngine {
   const ready = ensureSchema(client, refs);
 
   const engine: MySqlQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       await ready;
 

--- a/src/engines/postgres.ts
+++ b/src/engines/postgres.ts
@@ -112,6 +112,10 @@ export function postgresEngine(options: PostgresEngineOptions): PostgresQueryEng
   const ready = ensureSchema(client, refs);
 
   const engine: PostgresQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       await ready;
 

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -384,6 +384,10 @@ export function redisEngine(options: RedisEngineOptions): RedisQueryEngine {
   const keyPrefix = normalizePrefix(options.keyPrefix ?? DEFAULT_KEY_PREFIX);
 
   const engine: RedisQueryEngine = {
+    capabilities: {
+      uniqueConstraints: "atomic",
+    },
+
     async get(collection, key) {
       const record = await loadDocumentRecord(client, keyPrefix, collection, key);
 


### PR DESCRIPTION
## Summary
This PR rolls unique-index enforcement coverage across the remaining adapters by making capability declarations explicit and enforcing unique writes atomically through a shared store-level guard.

Closes #11.

## What changed
- Declare explicit unique-constraint capabilities for:
  - `postgres`
  - `mysql`
  - `mongodb`
  - `dynamodb`
  - `redis`
  - `cassandra`
  - `firestore`
  - `indexeddb`
- Add a shared unique write guard in `src/store.ts` that:
  - acquires an engine-backed lock for unique writes
  - validates candidate unique index values against existing indexed records
  - rejects duplicates before write with `UniqueConstraintError`
  - runs for `create`, `update`, `batchSet`, lazy migration writeback, and migration persistence
- Extend integration coverage in `tests/integration/migration-suite.ts` with unique duplicate behavior tests for:
  - duplicate `create`
  - duplicate `update`
  - duplicate `batchSet` (atomic failure)
- Add required changeset: `.changeset/serious-geese-bow.md`

## Why this design
Several adapters did not previously enforce unique indexes directly in write paths. The store-level lock + indexed preflight check provides atomic unique behavior consistently across adapters while preserving adapter-specific storage internals.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`
