### PR TITLE
ci(workflows): use frozen lockfile in quality and test

### DIFF
--- a/.changeset/every-zebras-cheat.md
+++ b/.changeset/every-zebras-cheat.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Update CI quality and test workflows to install dependencies with `bun install --frozen-lockfile` for deterministic dependency resolution.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -19,7 +19,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run lint check
         run: bun lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run test suite
         run: bun run test


### PR DESCRIPTION
## Summary
Use deterministic Bun installs in the quality and test CI workflows by enabling frozen lockfile mode.

Closes #12.

## Changes
- Update `/Users/samuellaycock/Development/nosql-odm/.github/workflows/quality.yml`
  - `bun install` -> `bun install --frozen-lockfile`
- Update `/Users/samuellaycock/Development/nosql-odm/.github/workflows/test.yml`
  - `bun install` -> `bun install --frozen-lockfile`
- Add required changeset
  - `/Users/samuellaycock/Development/nosql-odm/.changeset/every-zebras-cheat.md`

## Why
This prevents dependency drift in CI by failing early if `bun.lock` and dependency metadata are out of sync.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`
