### PR TITLE
fix: mark adapter peer dependencies optional

### DIFF
--- a/.changeset/tall-pandas-arrive.md
+++ b/.changeset/tall-pandas-arrive.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Mark engine adapter peer dependencies as optional via `peerDependenciesMeta` so consumers only need to install the database drivers they actually use.
+
+Clarify installation requirements in the README by explicitly noting that adapter peers are optional and documenting `mysql2` and `pg` install commands.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ In other words, the ODM acts as a type-safe proxy over the engine contract. Adap
 npm install nosql-odm zod
 ```
 
+Adapter packages are optional peer dependencies. Install only the engine package(s) you use.
+
 For SQLite support:
 
 ```bash
@@ -62,6 +64,18 @@ For Firestore support:
 
 ```bash
 npm install @google-cloud/firestore
+```
+
+For MySQL support:
+
+```bash
+npm install mysql2
+```
+
+For Postgres support:
+
+```bash
+npm install pg
 ```
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -148,5 +148,31 @@
     "pg": "^8.18.0",
     "redis": "^5.11.0",
     "typescript": "^5"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/lib-dynamodb": {
+      "optional": true
+    },
+    "@google-cloud/firestore": {
+      "optional": true
+    },
+    "better-sqlite3": {
+      "optional": true
+    },
+    "cassandra-driver": {
+      "optional": true
+    },
+    "mongodb": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "pg": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add `peerDependenciesMeta` entries to mark adapter driver peers as optional
- keep `typescript` as a required peer dependency
- clarify installation guidance in README by explicitly noting adapter peers are optional and adding MySQL/Postgres install requirements
- add a patch changeset for release notes

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #13
