### PR TITLE
fix: validate duplicate model index definitions

### DIFF
--- a/.changeset/friendly-pianos-smile.md
+++ b/.changeset/friendly-pianos-smile.md
@@ -2,6 +2,6 @@
 "nosql-odm": patch
 ---
 
-Validate model index definitions at build time to reject duplicate static index names and duplicate dynamic index storage keys with clear runtime errors.
+Validate model index definitions at build time to reject duplicate static index names, duplicate dynamic index storage keys, and collisions between static index names and dynamic storage keys with clear runtime errors.
 
 Add unit tests covering duplicate detection and error messages for both static and dynamic index definitions.

--- a/src/model.ts
+++ b/src/model.ts
@@ -533,24 +533,23 @@ class ModelBuilderImpl<
   }
 
   private validateIndexes(): void {
-    const staticIndexNames = new Set<string>();
-    const dynamicIndexKeys = new Set<string>();
+    const keyCategories = new Map<string, "static index name" | "dynamic index key">();
 
     for (const index of this.indexes) {
-      if (typeof index.name === "string") {
-        if (staticIndexNames.has(index.name)) {
-          throw new Error(`Model "${this.name}" has duplicate static index name "${index.name}"`);
+      const category = typeof index.name === "string" ? "static index name" : "dynamic index key";
+      const existingCategory = keyCategories.get(index.key);
+
+      if (existingCategory) {
+        if (existingCategory === category) {
+          throw new Error(`Model "${this.name}" has duplicate ${category} "${index.key}"`);
         }
 
-        staticIndexNames.add(index.name);
-        continue;
+        throw new Error(
+          `Model "${this.name}" has duplicate index key "${index.key}" shared by a ${existingCategory} and a ${category}`,
+        );
       }
 
-      if (dynamicIndexKeys.has(index.key)) {
-        throw new Error(`Model "${this.name}" has duplicate dynamic index key "${index.key}"`);
-      }
-
-      dynamicIndexKeys.add(index.key);
+      keyCategories.set(index.key, category);
     }
   }
 }

--- a/tests/unit/model.test.ts
+++ b/tests/unit/model.test.ts
@@ -227,6 +227,21 @@ describe("builder validation", () => {
         .build();
     }).toThrow('Model "user" has duplicate dynamic index key "tenantIdx_v1"');
   });
+
+  test("throws when static index name collides with dynamic index key", () => {
+    expect(() => {
+      model("user")
+        .schema(1, z.object({ id: z.string(), tenantId: z.string(), email: z.string() }))
+        .index({ name: "tenantIdx_v1", value: "email" })
+        .index("tenantIdx_v1", {
+          name: (data) => `tenant#${data.tenantId}`,
+          value: (data) => data.id,
+        })
+        .build();
+    }).toThrow(
+      'Model "user" has duplicate index key "tenantIdx_v1" shared by a static index name and a dynamic index key',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add build-time model validation for duplicate static index names
- add build-time model validation for duplicate dynamic index storage keys
- keep validation in the builder/build path so invalid index definitions fail fast before runtime usage
- add unit tests covering both duplicate scenarios and their error messages
- add a patch changeset for release notes

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #14
