### PR TITLE
fix: reject resolved index-name collisions at runtime

### DIFF
--- a/.changeset/odd-lemons-judge.md
+++ b/.changeset/odd-lemons-judge.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Detect resolved index-name collisions at runtime when building index key maps, and throw deterministic errors that include the model name and conflicting index identifiers.
+
+Add unit tests for static+dynamic and dynamic+dynamic resolved name collision scenarios.


### PR DESCRIPTION
## Summary
- detect runtime resolved index-name collisions in model index resolution to prevent silent overwrite behavior
- throw deterministic errors including model name, resolved runtime index name, and the two conflicting index identifiers
- apply collision detection to shared resolution logic used by both full index maps and unique-only index maps
- add unit tests for static+dynamic and dynamic+dynamic resolved-name collision scenarios
- add a patch changeset for release notes

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #15
