### PR TITLE
fix: add DocumentNotFoundError for update() missing-key paths

### DIFF
--- a/.changeset/quick-paws-smile.md
+++ b/.changeset/quick-paws-smile.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Add and export `DocumentNotFoundError` for `store.update()` missing-document paths, including concurrent delete handling when the engine reports not found.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
 export {
   createStore,
   DocumentAlreadyExistsError,
+  DocumentNotFoundError,
   MigrationProjectionError,
   MigrationAlreadyRunningError,
   MissingMigratorError,

--- a/src/store.ts
+++ b/src/store.ts
@@ -163,6 +163,13 @@ export class DocumentAlreadyExistsError extends Error {
   }
 }
 
+export class DocumentNotFoundError extends Error {
+  constructor(collection: string, key: string) {
+    super(`Document "${key}" not found in model "${collection}"`);
+    this.name = "DocumentNotFoundError";
+  }
+}
+
 export class UniqueConstraintError extends Error {
   readonly collection: string;
   readonly key: string;
@@ -460,7 +467,7 @@ class BoundModelImpl<
     const existing = await this.engine.get(this.model.name, key, options);
 
     if (existing === null || existing === undefined) {
-      throw new Error(`Document "${key}" not found in model "${this.model.name}"`);
+      throw new DocumentNotFoundError(this.model.name, key);
     }
 
     const existingDoc = existing as Record<string, unknown>;
@@ -497,7 +504,7 @@ class BoundModelImpl<
       });
     } catch (error) {
       if (error instanceof EngineDocumentNotFoundError) {
-        throw new Error(`Document "${key}" not found in model "${this.model.name}"`);
+        throw new DocumentNotFoundError(this.model.name, key);
       }
       if (error instanceof EngineUniqueConstraintError) {
         throw new UniqueConstraintError(


### PR DESCRIPTION
## Summary
- add a dedicated `DocumentNotFoundError` class to the store API
- map both `store.update()` missing-key paths to `DocumentNotFoundError` (pre-read miss and engine concurrent delete miss)
- export `DocumentNotFoundError` from `src/index.ts`
- add regression tests asserting typed error identity and message behavior
- add a patch changeset for release notes

## Why
Issue #31 identified inconsistent update not-found behavior using generic `Error`, which made reliable `instanceof` checks impossible for consumers.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

## Notes
- `bun test` (all files, including integration suites) was attempted and hit expected local service connectivity failures for MySQL when services were not running.

Closes #31
