### PR TITLE
fix: protect lazy migration writebacks from concurrent clobbering

### DIFF
--- a/.changeset/ten-melons-flow.md
+++ b/.changeset/ten-melons-flow.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Protect lazy migration writebacks from clobbering concurrent updates by propagating optimistic write tokens through store read paths and using conditional `batchSetWithResult` writes (including conflict skip hooks).

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -160,6 +160,14 @@ export interface KeyedDocument {
   writeToken?: string;
 }
 
+export interface EngineGetResult {
+  doc: unknown;
+  /**
+   * Optional engine-specific optimistic-write token for conditional updates.
+   */
+  writeToken?: string;
+}
+
 /**
  * Engine-level query result. Unlike the user-facing QueryResult, documents
  * include their storage keys.
@@ -224,6 +232,11 @@ export interface QueryEngine<TOptions = Record<string, unknown>> {
   };
 
   get(collection: string, key: string, options?: TOptions): Promise<unknown>;
+  getWithMetadata?(
+    collection: string,
+    key: string,
+    options?: TOptions,
+  ): Promise<EngineGetResult | null>;
 
   /**
    * Creates a new document. Must reject with EngineDocumentAlreadyExistsError
@@ -266,8 +279,18 @@ export interface QueryEngine<TOptions = Record<string, unknown>> {
   delete(collection: string, key: string, options?: TOptions): Promise<void>;
 
   query(collection: string, params: QueryParams, options?: TOptions): Promise<EngineQueryResult>;
+  queryWithMetadata?(
+    collection: string,
+    params: QueryParams,
+    options?: TOptions,
+  ): Promise<EngineQueryResult>;
 
   batchGet(collection: string, keys: string[], options?: TOptions): Promise<KeyedDocument[]>;
+  batchGetWithMetadata?(
+    collection: string,
+    keys: string[],
+    options?: TOptions,
+  ): Promise<KeyedDocument[]>;
   batchSet(collection: string, items: BatchSetItem[], options?: TOptions): Promise<void>;
   batchSetWithResult?(
     collection: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export type {
   ComparableVersion,
   ResolvedIndexKeys,
   BatchSetItem,
+  EngineGetResult,
   FieldCondition,
   QueryFilter,
   WhereFilter,


### PR DESCRIPTION
## Summary
- propagates optimistic write tokens through store lazy read paths (findByKey, query, and batchGet)
- adds metadata-aware read methods to token-capable engines so lazy writeback can include expectedWriteToken
- switches lazy writeback persistence to batchSetWithResult when available and skips conflicted writes safely
- emits projection skip hook events with reason `concurrent_write` for conflicted lazy writebacks
- adds regression coverage for token propagation, metadata method preference, and conflict skipping
- includes a changeset entry for release/versioning

## Why
Lazy migration writebacks previously persisted migrated data unconditionally. If a document changed concurrently between read and writeback, stale migrated data could overwrite newer writes.

## Testing
- bun run fmt
- bun run lint:fix
- bun run typecheck
- bun run test

Closes #32
