### PR TITLE
feat(ci): add scheduled full integration matrix

### DIFF
--- a/.changeset/few-rabbits-think.md
+++ b/.changeset/few-rabbits-think.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Add a nightly GitHub Actions full integration matrix that runs every adapter test regardless of PR path filters, with manual dispatch support for on-demand validation.
+
+Document the CI coverage model in the README so contributors understand the fast PR path versus the scheduled full-matrix safety net.

--- a/.github/workflows/integration-full-matrix.yml
+++ b/.github/workflows/integration-full-matrix.yml
@@ -1,0 +1,85 @@
+name: 🧪🌙 Full Integration Matrix
+
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - engine: memory
+            timeout: 20
+            service_up: ""
+            service_down: ""
+          - engine: indexeddb
+            timeout: 20
+            service_up: ""
+            service_down: ""
+          - engine: sqlite
+            timeout: 20
+            service_up: ""
+            service_down: ""
+          - engine: dynamodb
+            timeout: 30
+            service_up: bun run services:up:dynamodb
+            service_down: bun run services:down:dynamodb
+          - engine: cassandra
+            timeout: 30
+            service_up: bun run services:up:cassandra
+            service_down: bun run services:down:cassandra
+          - engine: redis
+            timeout: 30
+            service_up: bun run services:up:redis
+            service_down: bun run services:down:redis
+          - engine: mongodb
+            timeout: 30
+            service_up: bun run services:up:mongodb
+            service_down: bun run services:down:mongodb
+          - engine: firestore
+            timeout: 30
+            service_up: bun run services:up:firestore
+            service_down: bun run services:down:firestore
+          - engine: mysql
+            timeout: 30
+            service_up: bun run services:up:mysql
+            service_down: bun run services:down:mysql
+          - engine: postgres
+            timeout: 30
+            service_up: bun run services:up:postgres
+            service_down: bun run services:down:postgres
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Start service (${{ matrix.engine }})
+        if: ${{ matrix.service_up != '' }}
+        run: ${{ matrix.service_up }}
+
+      - name: Run integration tests (${{ matrix.engine }})
+        run: bun run test:integration:${{ matrix.engine }}
+
+      - name: Stop service (${{ matrix.engine }})
+        if: ${{ always() && matrix.service_down != '' }}
+        run: ${{ matrix.service_down }}

--- a/README.md
+++ b/README.md
@@ -521,6 +521,12 @@ bun run test:integration:postgres            # only Postgres integration
 
 The DynamoDB integration suite creates and deletes its own test table automatically.
 
+CI workflow coverage:
+
+- Pull requests run `test.yml` (unit suite) and path-filtered adapter integration workflows for fast feedback.
+- `.github/workflows/integration-full-matrix.yml` runs the full adapter integration matrix nightly at `04:00 UTC` and supports manual runs via `workflow_dispatch`.
+- `.github/workflows/publish.yml` keeps release gating focused on quality checks, unit tests, and smoke integrations.
+
 ## CRUD
 
 `create` requires an explicit key:


### PR DESCRIPTION
## Summary
- add .github/workflows/integration-full-matrix.yml to run all adapter integration suites nightly (0 4 * * *) and via manual dispatch
- keep PR path-filtered adapter workflows unchanged for fast feedback, while adding a recurring full-matrix safety net
- document fast-path vs full-matrix CI coverage in README.md
- add a changeset entry for release-note compliance

## Testing
- bun run fmt
- bun run lint:fix
- bun run test
- bun run typecheck

## Issue
Closes #36