### PR TITLE
fix(ci): trigger adapter integration workflows on shared helper changes

### DIFF
--- a/.changeset/neat-falcons-flash.md
+++ b/.changeset/neat-falcons-flash.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Expand adapter integration workflow `pull_request.paths` filters to include shared integration helper files.
+
+This ensures CI integration workflows run when `tests/integration/helpers.ts` or `tests/integration/migration-suite.ts` changes.

--- a/.github/workflows/integration-cassandra.yml
+++ b/.github/workflows/integration-cassandra.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/cassandra.ts"
       - "tests/integration/cassandra-engine.test.ts"

--- a/.github/workflows/integration-dynamodb.yml
+++ b/.github/workflows/integration-dynamodb.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/dynamodb.ts"
       - "tests/integration/dynamodb-engine.test.ts"

--- a/.github/workflows/integration-firestore.yml
+++ b/.github/workflows/integration-firestore.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/firestore.ts"
       - "tests/integration/firestore-engine.test.ts"

--- a/.github/workflows/integration-indexeddb.yml
+++ b/.github/workflows/integration-indexeddb.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/indexeddb.ts"
       - "tests/integration/indexeddb-engine.test.ts"

--- a/.github/workflows/integration-memory.yml
+++ b/.github/workflows/integration-memory.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/memory.ts"
       - "tests/integration/memory-engine.test.ts"

--- a/.github/workflows/integration-mongodb.yml
+++ b/.github/workflows/integration-mongodb.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/mongodb.ts"
       - "tests/integration/mongodb-engine.test.ts"

--- a/.github/workflows/integration-mysql.yml
+++ b/.github/workflows/integration-mysql.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/mysql.ts"
       - "tests/integration/mysql-engine.test.ts"

--- a/.github/workflows/integration-postgres.yml
+++ b/.github/workflows/integration-postgres.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/postgres.ts"
       - "tests/integration/postgres-engine.test.ts"

--- a/.github/workflows/integration-redis.yml
+++ b/.github/workflows/integration-redis.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/redis.ts"
       - "tests/integration/redis-engine.test.ts"

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -9,6 +9,8 @@ on:
       - "src/model.ts"
       - "src/migrator.ts"
       - "src/engines/types.ts"
+      - "tests/integration/helpers.ts"
+      - "tests/integration/migration-suite.ts"
       # Adapter-specific files
       - "src/engines/sqlite.ts"
       - "tests/integration/sqlite-engine.test.ts"


### PR DESCRIPTION
## Summary
This PR fixes a CI trigger gap where shared integration test utility changes did not trigger adapter-specific integration workflows.

## What changed
- Added tests/integration/helpers.ts to pull_request.paths in every integration adapter workflow.
- Added tests/integration/migration-suite.ts to pull_request.paths in every integration adapter workflow.
- Added a patch changeset documenting the CI trigger fix.

## Why
Previously, adapter workflow path filters covered adapter-specific files plus selected core files, but missed shared integration helper files. That allowed helper changes to bypass adapter integration CI.

## Validation
Ran the required local checks:
- bun run fmt
- bun run lint:fix
- bun run test
- bun run typecheck

## Result
Changes to shared integration helper logic now trigger relevant adapter integration workflows and remove the blind spot described in Issue #35.

Closes #35
