### PR TITLE
fix: prevent store.update() from overwriting concurrent writes

### DIFF
--- a/.changeset/khaki-birds-sleep.md
+++ b/.changeset/khaki-birds-sleep.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Prevent `store.update()` from silently overwriting concurrent writes when the engine exposes optimistic write tokens.
+
+`update()` now reads via `getWithMetadata()` when available and performs a conditional single-document write using `batchSetWithResult()`. When the conditional write conflicts, the store throws a new `ConcurrentWriteError` instead of silently clobbering the newer document state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export {
 
 export {
   createStore,
+  ConcurrentWriteError,
   DocumentAlreadyExistsError,
   DocumentNotFoundError,
   MigrationProjectionError,


### PR DESCRIPTION
## Summary
Fixes a lost-update bug in `store.update()` when engines expose optimistic write tokens.

Previously, `update()` always used `engine.get()` followed by `engine.update()`, so concurrent writes could be silently overwritten. This change makes `update()` use metadata reads when available and perform a conditional write to detect conflicts.

## Changes
- Use `getWithMetadata()` in `BoundModelImpl.update()` via the existing `getWithOptionalWriteToken()` helper.
- When a write token is present and the engine supports `batchSetWithResult()`, perform a single-document conditional write using `expectedWriteToken`.
- Throw a new exported `ConcurrentWriteError` when the conditional write reports a conflict.
- Add unit regression tests covering token propagation and conflict behavior.
- Add a changeset for the patch release.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

## Changeset
- Added `.changeset/khaki-birds-sleep.md`

Closes #51
