### PR TITLE
fix(store): require filter for indexed queries

### DIFF
--- a/.changeset/swift-pens-jog.md
+++ b/.changeset/swift-pens-jog.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Prevent `store.query()` from silently falling back to a full collection scan when `index` is provided without `filter`.
+
+The store now validates `index` and `filter` as a required pair before resolving query params, and throws a clear error for malformed queries instead of passing them through to engine scan paths.

--- a/src/store.ts
+++ b/src/store.ts
@@ -1471,10 +1471,19 @@ class BoundModelImpl<
     params: ModelQueryParams<TStaticIndexNames, THasDynamicIndexes>,
   ): QueryParams {
     const hasIndex = params.index !== undefined;
+    const hasFilter = params.filter !== undefined;
     const hasWhere = params.where !== undefined;
 
-    if (hasIndex && hasWhere) {
+    if ((hasIndex || hasFilter) && hasWhere) {
       throw new Error(`Cannot use both "index"/"filter" and "where" in the same query`);
+    }
+
+    if (hasIndex !== hasFilter) {
+      if (hasIndex) {
+        throw new Error('query params with "index" must also include "filter"');
+      }
+
+      throw new Error('query params with "filter" must also include "index"');
     }
 
     if (hasWhere) {

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -1195,6 +1195,20 @@ describe("store.query()", () => {
     expect(results.documents).toHaveLength(2);
   });
 
+  test('throws when "index" is provided without "filter"', async () => {
+    const store = createStore(engine, [buildUserV1()]);
+
+    await store.user.create("u1", {
+      id: "u1",
+      name: "Sam",
+      email: "sam@example.com",
+    });
+
+    expect(store.user.query({ index: "byEmail" })).rejects.toThrow(
+      'query params with "index" must also include "filter"',
+    );
+  });
+
   test("paginates all documents with no filter", async () => {
     const store = createStore(engine, [buildUserV1()]);
 


### PR DESCRIPTION
## Summary
- validate `index` and `filter` as a required pair in `resolveQuery()` before passing query params to the engine
- prevent malformed indexed queries (for example `{ index: "byEmail" }`) from silently falling back to a full collection scan
- add a unit regression test covering the `index`-without-`filter` case
- add a patch changeset for `nosql-odm`

## Testing
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`

Closes #52