### PR TITLE
feat(store): allow store-managed unique constraints on non-atomic engines

### DIFF
--- a/.changeset/wise-badgers-float.md
+++ b/.changeset/wise-badgers-float.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": minor
+---
+
+Add an explicit `allowStoreManagedUniqueConstraints` `createStore()` option to allow models with unique indexes when an engine declares `capabilities.uniqueConstraints = "none"`.
+
+When enabled, the store accepts those models and relies on the existing store-managed lock + uniqueness pre-check guard path instead of requiring engine-level atomic unique constraints.

--- a/src/store.ts
+++ b/src/store.ts
@@ -277,6 +277,13 @@ export interface CreateStoreOptions<TOptions = Record<string, unknown>> {
   migrator?: Migrator<TOptions>;
   migrationHooks?: MigrationHooks;
   projectionHooks?: ProjectionHooks;
+  /**
+   * Allows models with `unique: true` indexes when the engine explicitly
+   * reports `capabilities.uniqueConstraints = "none"`. The store will use its
+   * lock + pre-check guard path instead of relying on engine-enforced atomic
+   * uniqueness.
+   */
+  allowStoreManagedUniqueConstraints?: boolean;
   uniqueConstraintPrecheck?: UniqueConstraintPrecheckOptions;
   uniqueConstraintLock?: UniqueConstraintLockOptions;
 }
@@ -1597,6 +1604,7 @@ export function createStore<
   const uniqueConstraintPrecheckConcurrency = resolveUniqueConstraintPrecheckConcurrency(
     options?.uniqueConstraintPrecheck,
   );
+  const allowStoreManagedUniqueConstraints = options?.allowStoreManagedUniqueConstraints === true;
   const boundModels = new Map<string, BoundModelImpl<any, TOptions, any, any>>();
 
   for (const modelDef of models) {
@@ -1606,9 +1614,19 @@ export function createStore<
 
     const hasUniqueIndexes = modelDef.indexes.some((index) => index.unique === true);
 
-    if (hasUniqueIndexes && engine.capabilities?.uniqueConstraints !== "atomic") {
+    const uniqueConstraintCapability = engine.capabilities?.uniqueConstraints;
+    const supportsAtomicUniqueConstraints = uniqueConstraintCapability === "atomic";
+    const supportsStoreManagedUniqueConstraints =
+      uniqueConstraintCapability === "none" && allowStoreManagedUniqueConstraints;
+
+    if (
+      hasUniqueIndexes &&
+      !supportsAtomicUniqueConstraints &&
+      !supportsStoreManagedUniqueConstraints
+    ) {
       throw new Error(
-        `Model "${modelDef.name}" declares unique indexes, but the configured engine does not support atomic unique constraints`,
+        `Model "${modelDef.name}" declares unique indexes, but the configured engine does not support atomic unique constraints. ` +
+          `Use createStore(..., { allowStoreManagedUniqueConstraints: true }) to opt into store-managed unique guards for engines that declare capabilities.uniqueConstraints = "none".`,
       );
     }
 


### PR DESCRIPTION
## Summary
- add an explicit `createStore()` opt-in (`allowStoreManagedUniqueConstraints`) for engines that declare `capabilities.uniqueConstraints = "none"`
- allow binding models with `unique: true` indexes in that mode and reuse the existing store-managed lock + pre-check guard path
- add a regression test that disables engine-side unique enforcement and verifies duplicate writes are still rejected
- include a changeset entry

## Why
Issue #54 points out that `BoundModelImpl` already implements a software unique-constraint guard, but `createStore()` rejected all non-atomic engines up front. This change makes that compatibility mode explicit and opt-in.

## Behavior
- default behavior is unchanged: unique indexes still fail fast unless the engine reports atomic unique constraints
- for engines that explicitly report `uniqueConstraints: "none"`, callers can opt in via `allowStoreManagedUniqueConstraints: true`
- the store continues to use its existing lock + uniqueness pre-check guard path for writes

## Tests
- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Closes #54