### PR TITLE
fix(store): optimize unique precheck conflict detection queries

### DIFF
--- a/.changeset/nice-apples-flow.md
+++ b/.changeset/nice-apples-flow.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Optimize store-managed unique precheck conflict detection by querying with `limit: 1` instead of `limit: 10`, since these probes only need to detect existence.
+
+Add a regression unit test that verifies unique precheck queries use existence-only limits during `batchSet()`.

--- a/src/store.ts
+++ b/src/store.ts
@@ -1451,7 +1451,7 @@ class BoundModelImpl<
           {
             index: indexName,
             filter: { value: indexValue },
-            limit: 10,
+            limit: 1,
           },
           options,
         );

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -277,6 +277,7 @@ interface UniquePrecheckTracker {
   inFlight: number;
   maxInFlight: number;
   values: string[];
+  limits: number[];
   lockAcquisitions: number;
   waiters: Array<() => void>;
 }
@@ -297,6 +298,9 @@ function createUniquePrecheckTrackingEngine(precheck: UniquePrecheckTracker): Qu
       const indexValue = (params.filter as { value?: string } | undefined)?.value;
       if (typeof indexValue === "string") {
         precheck.values.push(indexValue);
+      }
+      if (typeof params.limit === "number") {
+        precheck.limits.push(params.limit);
       }
 
       precheck.inFlight += 1;
@@ -452,6 +456,7 @@ describe("unique indexes", () => {
       inFlight: 0,
       maxInFlight: 0,
       values: [],
+      limits: [],
       lockAcquisitions: 0,
       waiters: [],
     };
@@ -541,6 +546,7 @@ describe("unique indexes", () => {
       inFlight: 0,
       maxInFlight: 0,
       values: [],
+      limits: [],
       lockAcquisitions: 0,
       waiters: [],
     };
@@ -570,6 +576,7 @@ describe("unique indexes", () => {
       inFlight: 0,
       maxInFlight: 0,
       values: [],
+      limits: [],
       lockAcquisitions: 0,
       waiters: [],
     };
@@ -589,6 +596,30 @@ describe("unique indexes", () => {
     ]);
 
     expect(precheck.maxInFlight).toBe(2);
+  });
+
+  test("batchSet uses existence-only limits for unique pre-check queries", async () => {
+    const precheck: UniquePrecheckTracker = {
+      inFlight: 0,
+      maxInFlight: 0,
+      values: [],
+      limits: [],
+      lockAcquisitions: 0,
+      waiters: [],
+    };
+    const trackingEngine = createUniquePrecheckTrackingEngine(precheck);
+    const store = createStore(trackingEngine, [buildUserV1WithUniqueEmail()], {
+      allowStoreManagedUniqueConstraints: true,
+    });
+
+    await store.user.batchSet([
+      { key: "u1", data: { id: "u1", name: "Sam", email: "sam@example.com" } },
+      { key: "u2", data: { id: "u2", name: "Jamie", email: "jamie@example.com" } },
+      { key: "u3", data: { id: "u3", name: "Casey", email: "casey@example.com" } },
+    ]);
+
+    expect(precheck.limits).toHaveLength(3);
+    expect(precheck.limits).toEqual([1, 1, 1]);
   });
 
   test("create allows multiple documents with missing optional unique index values", async () => {


### PR DESCRIPTION
## Summary
- Reduce store-managed unique precheck conflict probes from `limit: 10` to `limit: 1` in `assertNoUniqueConstraintConflicts()`.
- Add a regression test that verifies `batchSet()` unique precheck queries use existence-only limits.
- Add a patch changeset for release notes.

## Why
Issue #56 identified that unique precheck conflict detection only needs existence checks, but currently fetches up to 10 documents per unique token. Lowering this to 1 reduces query/load overhead for batch writes with many unique values.

## Changes
- `src/store.ts`: change unique precheck query limit from `10` to `1`.
- `tests/unit/store.test.ts`:
  - extend the precheck tracker helper to capture query limits,
  - add `batchSet uses existence-only limits for unique pre-check queries` regression test,
  - initialize the new tracker field in existing unique precheck tests.
- `.changeset/nice-apples-flow.md`: patch changeset describing the optimization.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun test` (fails in this environment for integration suites that require running external services: mysql, firestore, cassandra, redis, mongodb, postgres, dynamodb)

Closes #56
