### PR TITLE
feat: add batchGetOrdered for ordered bulk reads

### DIFF
--- a/.changeset/issue-75-batch-get-ordered.md
+++ b/.changeset/issue-75-batch-get-ordered.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": minor
+---
+
+Add `store.<model>.batchGetOrdered(keys)` to preserve requested key order, retain duplicate positions, and include `null` placeholders for missing or skipped documents without changing the existing `batchGet()` contract.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A lightweight, schema-first ODM for NoSQL-style data stores.
 - Optional strict migration error mode (`migrationErrors: "throw"`)
 - Ignore-first migration behavior for non-migratable documents
 - Dynamic index names (multi-tenant style index partitions)
-- Explicit bulk operations (`batchGet`, `batchSet`, `batchDelete`)
+- Explicit bulk operations (`batchGet`, `batchGetOrdered`, `batchSet`, `batchDelete`)
 - Pluggable query engine interface (memory, SQLite, IndexedDB, DynamoDB, Cassandra, Redis, MongoDB, and Firestore adapters included)
 
 ## Package Intent
@@ -581,7 +581,17 @@ await store.user.batchSet([
 ]);
 
 await store.user.batchDelete(["u2", "u3"]);
+
+const orderedUsers = await store.user.batchGetOrdered(["u3", "missing", "u2", "u3"]);
+// => [
+//   { id: "u3", firstName: "Alex", lastName: "Smith", email: "alex@example.com", role: "guest" },
+//   null,
+//   { id: "u2", firstName: "Jane", lastName: "Doe", email: "jane@example.com", role: "member" },
+//   { id: "u3", firstName: "Alex", lastName: "Smith", email: "alex@example.com", role: "guest" },
+// ]
 ```
+
+`batchGet()` keeps its existing "found documents only" behavior. Use `batchGetOrdered()` when you need positional parity with the requested keys, including `null` placeholders for missing documents.
 
 ## Querying
 
@@ -1048,6 +1058,7 @@ Read-path handling for skipped docs:
 
 - `findByKey()` returns `null`
 - `query()` and `batchGet()` omit them
+- `batchGetOrdered()` returns `null` placeholders to preserve request order
 
 ### 10. Event hooks
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -126,6 +126,7 @@ export interface BoundModel<
   delete(key: string, options?: TOptions): Promise<void>;
 
   batchGet(keys: string[], options?: TOptions): Promise<T[]>;
+  batchGetOrdered(keys: string[], options?: TOptions): Promise<(T | null)[]>;
   batchSet(items: BatchSetInputItem<T>[], options?: TOptions): Promise<T[]>;
   batchDelete(keys: string[], options?: TOptions): Promise<void>;
 
@@ -751,10 +752,60 @@ class BoundModelImpl<
   }
 
   async batchGet(keys: string[], options?: TOptions): Promise<T[]> {
+    const results = await this.projectBatchGetResults(keys, options);
+    return results.map((result) => result.value);
+  }
+
+  async batchGetOrdered(keys: string[], options?: TOptions): Promise<(T | null)[]> {
+    const results = await this.projectBatchGetResults(keys, options);
+    const valuesByKey = new Map<
+      string,
+      {
+        fallback: T;
+        nextIndex: number;
+        values: T[];
+      }
+    >();
+
+    for (const result of results) {
+      const existing = valuesByKey.get(result.key);
+
+      if (existing) {
+        existing.values.push(result.value);
+      } else {
+        valuesByKey.set(result.key, {
+          fallback: result.value,
+          nextIndex: 0,
+          values: [result.value],
+        });
+      }
+    }
+
+    return keys.map((key) => {
+      const queued = valuesByKey.get(key);
+
+      if (!queued) {
+        return null;
+      }
+
+      if (queued.nextIndex < queued.values.length) {
+        const value = queued.values[queued.nextIndex];
+        queued.nextIndex += 1;
+        return value!;
+      }
+
+      return structuredClone(queued.fallback);
+    });
+  }
+
+  private async projectBatchGetResults(
+    keys: string[],
+    options?: TOptions,
+  ): Promise<{ key: string; value: T }[]> {
     const rawDocs = this.engine.batchGetWithMetadata
       ? await this.engine.batchGetWithMetadata(this.model.name, keys, options)
       : await this.engine.batchGet(this.model.name, keys, options);
-    const results: T[] = [];
+    const results: { key: string; value: T }[] = [];
     const writebacks: { key: string; value: T; expectedWriteToken?: string }[] = [];
 
     for (const { key, doc: rawDoc, writeToken } of rawDocs) {
@@ -773,7 +824,7 @@ class BoundModelImpl<
         });
       }
 
-      results.push(projected.value);
+      results.push({ key, value: projected.value });
     }
 
     await this.writebackMany(writebacks, "batchGet", options);
@@ -1858,6 +1909,7 @@ export function createStore<
       update: boundModel.update.bind(boundModel),
       delete: boundModel.delete.bind(boundModel),
       batchGet: boundModel.batchGet.bind(boundModel),
+      batchGetOrdered: boundModel.batchGetOrdered.bind(boundModel),
       batchSet: boundModel.batchSet.bind(boundModel),
       batchDelete: boundModel.batchDelete.bind(boundModel),
       getOrCreateMigration: boundModel.getOrCreateMigration.bind(boundModel),

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -2194,6 +2194,130 @@ describe("store.batchGet()", () => {
 });
 
 // ---------------------------------------------------------------------------
+// CRUD - batchGetOrdered
+// ---------------------------------------------------------------------------
+
+describe("store.batchGetOrdered()", () => {
+  test("returns documents in request order and includes nulls for missing keys", async () => {
+    const store = createStore(engine, [buildUserV1()]);
+
+    await store.user.create("u1", {
+      id: "u1",
+      name: "Sam",
+      email: "sam@example.com",
+    });
+    await store.user.create("u2", {
+      id: "u2",
+      name: "Other",
+      email: "other@example.com",
+    });
+
+    const results = await store.user.batchGetOrdered(["u2", "missing", "u1", "u2"]);
+
+    expect(results).toEqual([
+      {
+        id: "u2",
+        name: "Other",
+        email: "other@example.com",
+      },
+      null,
+      {
+        id: "u1",
+        name: "Sam",
+        email: "sam@example.com",
+      },
+      {
+        id: "u2",
+        name: "Other",
+        email: "other@example.com",
+      },
+    ]);
+    expect(results[0]).not.toBeNull();
+    expect(results[3]).not.toBeNull();
+    expect(results[0]).not.toBe(results[3]);
+  });
+
+  test("reconstructs ordered results from unordered engine.batchGet responses", async () => {
+    const calls: string[] = [];
+    const trackingEngine: QueryEngine<never> = {
+      async get() {
+        calls.push("get");
+        throw new Error("batchGetOrdered should not call engine.get");
+      },
+      async create() {},
+      async put() {},
+      async update() {},
+      async delete() {},
+      async query() {
+        return { documents: [], cursor: null };
+      },
+      async batchGet() {
+        calls.push("batchGet");
+        return [
+          {
+            key: "u1",
+            doc: {
+              __v: 1,
+              __indexes: ["byEmail", "primary"],
+              id: "u1",
+              name: "Sam",
+              email: "sam@example.com",
+            },
+          },
+          {
+            key: "u2",
+            doc: {
+              __v: 1,
+              __indexes: ["byEmail", "primary"],
+              id: "u2",
+              name: "Other",
+              email: "other@example.com",
+            },
+          },
+        ];
+      },
+      async batchSet() {},
+      async batchDelete() {},
+      migration: {
+        async acquireLock() {
+          return null;
+        },
+        async releaseLock() {},
+        async getOutdated() {
+          return { documents: [], cursor: null };
+        },
+      },
+    };
+
+    const store = createStore(trackingEngine, [buildUserV1()]);
+    const results = await store.user.batchGetOrdered(["u2", "missing", "u1", "u2"]);
+
+    expect(results).toEqual([
+      {
+        id: "u2",
+        name: "Other",
+        email: "other@example.com",
+      },
+      null,
+      {
+        id: "u1",
+        name: "Sam",
+        email: "sam@example.com",
+      },
+      {
+        id: "u2",
+        name: "Other",
+        email: "other@example.com",
+      },
+    ]);
+    expect(results[0]).not.toBeNull();
+    expect(results[3]).not.toBeNull();
+    expect(results[0]).not.toBe(results[3]);
+    expect(calls).toEqual(["batchGet"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CRUD — batchSet
 // ---------------------------------------------------------------------------
 
@@ -5744,6 +5868,22 @@ describe("engine options passthrough", () => {
 
     expect(calls).toHaveLength(1);
     expect((calls[0] as any).options).toEqual({ trace: "batch-get-trace" });
+  });
+
+  test("batchGetOrdered passes options to engine.batchGet", async () => {
+    const calls: unknown[] = [];
+    const trackingEngine = buildTrackingEngine(calls, {
+      async batchGet(_collection, _ids, options) {
+        calls.push({ method: "batchGet", options });
+        return [];
+      },
+    });
+
+    const store = createStore(trackingEngine, [buildUserV1()]);
+    await store.user.batchGetOrdered(["u1", "u2"], { trace: "batch-get-ordered-trace" });
+
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as any).options).toEqual({ trace: "batch-get-ordered-trace" });
   });
 
   test("batchDelete passes options to engine.batchDelete when available", async () => {


### PR DESCRIPTION
## Summary
- add store.<model>.batchGetOrdered(keys) to preserve requested key order, keep duplicate positions, and return null placeholders for missing or skipped documents
- reuse the existing batchGet projection and lazy-writeback path so ordered reads keep the same migration behavior and engine option passthrough
- document when to use batchGetOrdered() vs batchGet() and include a minor changeset for the new public API

## Testing
- bun run fmt
- bun run typecheck
- bun run test

Closes #75