### PR TITLE
[codex] Fix MongoDB query cursor handling

### DIFF
--- a/.changeset/mongo-query-cursors.md
+++ b/.changeset/mongo-query-cursors.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Fix MongoDB query pagination to use opaque, query-bound cursors across native and fallback execution paths.

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -1090,12 +1090,7 @@ async function queryDocumentsNative(
   let queryFilter = plan.filter;
 
   if (params.cursor) {
-    const cursorPosition = resolveQueryPageCursorPosition(plan.collection, params);
-
-    if (!cursorPosition) {
-      throw new Error("Invalid query cursor");
-    }
-
+    const cursorPosition = resolveQueryPageCursorPosition(plan.collection, params)!;
     const cursorPredicate = buildMongoCursorPredicate(cursorPosition, plan, params);
 
     if (cursorPredicate) {

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -1,6 +1,13 @@
 import { DefaultMigrator } from "../migrator";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import {
+  encodeQueryPageCursor,
+  resolveQueryPageCursorPosition,
+  resolveQueryPageStartIndex,
+  type QueryCursorPosition,
+  type QueryCursorRecordPosition,
+} from "./query-cursor";
+import {
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
@@ -333,7 +340,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
       const records = await listCollectionDocuments(documentsCollection, collection);
       const matched = matchDocuments(records, params);
 
-      return paginate(matched, params);
+      return paginate(collection, matched, params);
     },
 
     async queryWithMetadata(collection, params) {
@@ -358,7 +365,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
       const records = await listCollectionDocuments(documentsCollection, collection);
       const matched = matchDocuments(records, params);
 
-      return paginateWithWriteTokens(matched, params);
+      return paginateWithWriteTokens(collection, matched, params);
     },
 
     async batchGet(collection, keys) {
@@ -1083,21 +1090,19 @@ async function queryDocumentsNative(
   let queryFilter = plan.filter;
 
   if (params.cursor) {
-    const cursorRaw = await documentsCollection.findOne({
-      collection: plan.collection,
-      key: params.cursor,
-    });
+    const cursorPosition = resolveQueryPageCursorPosition(plan.collection, params);
 
-    if (cursorRaw) {
-      const cursorRecord = parseStoredDocumentRecord(cursorRaw);
-      const cursorPredicate = buildMongoCursorPredicate(cursorRecord, plan, params);
+    if (!cursorPosition) {
+      throw new Error("Invalid query cursor");
+    }
 
-      if (cursorPredicate) {
-        queryFilter = {
-          ...queryFilter,
-          ...cursorPredicate,
-        };
-      }
+    const cursorPredicate = buildMongoCursorPredicate(cursorPosition, plan, params);
+
+    if (cursorPredicate) {
+      queryFilter = {
+        ...queryFilter,
+        ...cursorPredicate,
+      };
     }
   }
 
@@ -1123,7 +1128,14 @@ async function queryDocumentsNative(
 
   return {
     records,
-    cursor: hasMore && records.length > 0 ? records[records.length - 1]!.key : null,
+    cursor:
+      hasMore && records.length > 0
+        ? encodeQueryPageCursor(
+            plan.collection,
+            params,
+            getQueryCursorRecordPosition(records[records.length - 1]!, params),
+          )
+        : null,
   };
 }
 
@@ -1260,55 +1272,75 @@ function escapeMongoRegex(value: string): string {
 }
 
 function buildMongoCursorPredicate(
-  cursorRecord: StoredDocumentRecord,
+  cursorPosition: QueryCursorPosition,
   plan: MongoNativeQueryPlan,
   params: QueryParams,
 ): Record<string, unknown> | null {
-  const cursorIndexValue = cursorRecord.indexes[plan.indexName];
-
-  if (cursorIndexValue === undefined || !matchesFilter(cursorIndexValue, params.filter!.value)) {
-    return null;
-  }
-
   if (!params.sort) {
+    if (cursorPosition.kind !== "scan") {
+      throw new Error("Query cursor no longer points to a valid result");
+    }
+
     return {
       $or: [
         {
           createdAt: {
-            $gt: cursorRecord.createdAt,
+            $gt: cursorPosition.createdAt,
           },
         },
         {
-          createdAt: cursorRecord.createdAt,
+          createdAt: cursorPosition.createdAt,
           key: {
-            $gt: cursorRecord.key,
+            $gt: cursorPosition.key,
           },
         },
       ],
     };
   }
 
+  if (cursorPosition.kind !== "sorted-index") {
+    throw new Error("Query cursor no longer points to a valid result");
+  }
+
   const indexField = `indexes.${plan.indexName}`;
   const primaryOp = params.sort === "desc" ? "$lt" : "$gt";
+
+  if (cursorPosition.createdAt === undefined) {
+    return {
+      $or: [
+        {
+          [indexField]: {
+            [primaryOp]: cursorPosition.indexValue,
+          },
+        },
+        {
+          [indexField]: cursorPosition.indexValue,
+          key: {
+            $gt: cursorPosition.key,
+          },
+        },
+      ],
+    };
+  }
 
   return {
     $or: [
       {
         [indexField]: {
-          [primaryOp]: cursorIndexValue,
+          [primaryOp]: cursorPosition.indexValue,
         },
       },
       {
-        [indexField]: cursorIndexValue,
+        [indexField]: cursorPosition.indexValue,
         createdAt: {
-          $gt: cursorRecord.createdAt,
+          $gt: cursorPosition.createdAt,
         },
       },
       {
-        [indexField]: cursorIndexValue,
-        createdAt: cursorRecord.createdAt,
+        [indexField]: cursorPosition.indexValue,
+        createdAt: cursorPosition.createdAt,
         key: {
-          $gt: cursorRecord.key,
+          $gt: cursorPosition.key,
         },
       },
     ],
@@ -2009,17 +2041,17 @@ function matchDocuments(
   return results;
 }
 
-function paginate(records: StoredDocumentRecord[], params: QueryParams): EngineQueryResult {
-  let startIndex = 0;
-
-  if (params.cursor) {
-    const cursorIndex = records.findIndex((record) => record.key === params.cursor);
-
-    if (cursorIndex !== -1) {
-      startIndex = cursorIndex + 1;
-    }
-  }
-
+function paginate(
+  collection: string,
+  records: StoredDocumentRecord[],
+  params: QueryParams,
+): EngineQueryResult {
+  const startIndex = resolveQueryPageStartIndex(
+    records,
+    collection,
+    params,
+    getQueryCursorRecordPosition,
+  );
   const normalizedLimit = normalizeLimit(params.limit);
   const limit = normalizedLimit ?? records.length;
   const hasLimit = normalizedLimit !== null;
@@ -2034,7 +2066,11 @@ function paginate(records: StoredDocumentRecord[], params: QueryParams): EngineQ
   const page = records.slice(startIndex, startIndex + limit);
   const cursor =
     page.length > 0 && hasLimit && startIndex + limit < records.length
-      ? page[page.length - 1]!.key
+      ? encodeQueryPageCursor(
+          collection,
+          params,
+          getQueryCursorRecordPosition(page[page.length - 1]!, params),
+        )
       : null;
 
   return {
@@ -2047,19 +2083,16 @@ function paginate(records: StoredDocumentRecord[], params: QueryParams): EngineQ
 }
 
 function paginateWithWriteTokens(
+  collection: string,
   records: StoredDocumentRecord[],
   params: QueryParams,
 ): EngineQueryResult {
-  let startIndex = 0;
-
-  if (params.cursor) {
-    const cursorIndex = records.findIndex((record) => record.key === params.cursor);
-
-    if (cursorIndex !== -1) {
-      startIndex = cursorIndex + 1;
-    }
-  }
-
+  const startIndex = resolveQueryPageStartIndex(
+    records,
+    collection,
+    params,
+    getQueryCursorRecordPosition,
+  );
   const normalizedLimit = normalizeLimit(params.limit);
   const limit = normalizedLimit ?? records.length;
   const hasLimit = normalizedLimit !== null;
@@ -2074,7 +2107,11 @@ function paginateWithWriteTokens(
   const page = records.slice(startIndex, startIndex + limit);
   const cursor =
     page.length > 0 && hasLimit && startIndex + limit < records.length
-      ? page[page.length - 1]!.key
+      ? encodeQueryPageCursor(
+          collection,
+          params,
+          getQueryCursorRecordPosition(page[page.length - 1]!, params),
+        )
       : null;
 
   return {
@@ -2084,6 +2121,17 @@ function paginateWithWriteTokens(
       writeToken: String(record.writeVersion),
     })),
     cursor,
+  };
+}
+
+function getQueryCursorRecordPosition(
+  record: StoredDocumentRecord,
+  params: QueryParams,
+): QueryCursorRecordPosition {
+  return {
+    key: record.key,
+    createdAt: record.createdAt,
+    indexValue: params.index ? (record.indexes[params.index] ?? "") : undefined,
   };
 }
 

--- a/tests/integration/mongodb-engine.test.ts
+++ b/tests/integration/mongodb-engine.test.ts
@@ -581,25 +581,26 @@ describe("mongoDbEngine integration", () => {
       limit: 1,
     });
 
-    expect(
-      engine.query(collection, {
-        index: "byRole",
-        filter: { value: { $begins: "member#" } },
-        sort: "asc",
-        cursor: "u1",
-        limit: 1,
-      }),
-    ).rejects.toThrow(/cursor/i);
-
-    expect(
-      engine.query(collection, {
-        index: "byRole",
-        filter: { value: { $begins: "admin#" } },
-        sort: "asc",
-        cursor: first.cursor ?? undefined,
-        limit: 1,
-      }),
-    ).rejects.toThrow(/cursor/i);
+    await Promise.all([
+      expect(
+        engine.query(collection, {
+          index: "byRole",
+          filter: { value: { $begins: "member#" } },
+          sort: "asc",
+          cursor: "u1",
+          limit: 1,
+        }),
+      ).rejects.toThrow(/cursor/i),
+      expect(
+        engine.query(collection, {
+          index: "byRole",
+          filter: { value: { $begins: "admin#" } },
+          sort: "asc",
+          cursor: first.cursor ?? undefined,
+          limit: 1,
+        }),
+      ).rejects.toThrow(/cursor/i),
+    ]);
   });
 
   test("query pagination remains stable when the cursor row is deleted", async () => {

--- a/tests/integration/mongodb-engine.test.ts
+++ b/tests/integration/mongodb-engine.test.ts
@@ -19,6 +19,7 @@ import {
   type ComparableVersion,
 } from "../../src";
 import { mongoDbEngine, type MongoDbQueryEngine } from "../../src/engines/mongodb";
+import { encodeQueryPageCursor } from "../../src/engines/query-cursor";
 import { runQueryEngineConformanceSuite } from "./conformance-suite";
 import {
   createCollectionNameFactory,
@@ -475,7 +476,22 @@ describe("mongoDbEngine integration", () => {
     });
 
     expect(first.documents.map((item) => item.key)).toEqual(["u1", "u3"]);
-    expect(first.cursor).toBe("u3");
+    expect(first.cursor).toBe(
+      encodeQueryPageCursor(
+        collection,
+        {
+          index: "byRole",
+          filter: { value: { $begins: "member#" } },
+          sort: "asc",
+          limit: 2,
+        },
+        {
+          key: "u3",
+          createdAt: 3,
+          indexValue: "member#b",
+        },
+      ),
+    );
     expect(second.documents.map((item) => item.key)).toEqual(["u2"]);
     expect(second.cursor).toBeNull();
   });
@@ -531,31 +547,85 @@ describe("mongoDbEngine integration", () => {
       limit: 1.9,
     });
 
-    const unknownCursor = await engine.query(collection, {
-      index: "byRole",
-      filter: { value: { $begins: "member#" } },
-      sort: "asc",
-      cursor: "unknown",
-      limit: 2,
-    });
-
-    const lastCursor = await engine.query(collection, {
-      index: "byRole",
-      filter: { value: { $begins: "member#" } },
-      sort: "asc",
-      cursor: "u3",
-      limit: 2,
-    });
-
     expect(limitZero.documents).toHaveLength(0);
     expect(limitZero.cursor).toBeNull();
     expect(noLimit.documents).toHaveLength(3);
     expect(noLimit.cursor).toBeNull();
     expect(fractional.documents).toHaveLength(1);
-    expect(fractional.cursor).toBe("u1");
-    expect(unknownCursor.documents.map((item) => item.key)).toEqual(["u1", "u2"]);
-    expect(lastCursor.documents).toHaveLength(0);
-    expect(lastCursor.cursor).toBeNull();
+    expect(fractional.cursor).toBe(
+      encodeQueryPageCursor(
+        collection,
+        {
+          index: "byRole",
+          filter: { value: { $begins: "member#" } },
+          sort: "asc",
+          limit: 1.9,
+        },
+        {
+          key: "u1",
+          createdAt: 1,
+          indexValue: "member#a",
+        },
+      ),
+    );
+  });
+
+  test("query rejects raw key cursors and mismatched query cursors", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put(collection, "u2", { id: "u2" }, { byRole: "member#b" });
+
+    const first = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+    });
+
+    expect(
+      engine.query(collection, {
+        index: "byRole",
+        filter: { value: { $begins: "member#" } },
+        sort: "asc",
+        cursor: "u1",
+        limit: 1,
+      }),
+    ).rejects.toThrow(/cursor/i);
+
+    expect(
+      engine.query(collection, {
+        index: "byRole",
+        filter: { value: { $begins: "admin#" } },
+        sort: "asc",
+        cursor: first.cursor ?? undefined,
+        limit: 1,
+      }),
+    ).rejects.toThrow(/cursor/i);
+  });
+
+  test("query pagination remains stable when the cursor row is deleted", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put(collection, "u2", { id: "u2" }, { byRole: "member#b" });
+    await engine.put(collection, "u3", { id: "u3" }, { byRole: "member#c" });
+
+    const first = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+    });
+
+    await engine.delete(collection, "u1");
+
+    const second = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      cursor: first.cursor ?? undefined,
+      limit: 2,
+    });
+
+    expect(second.documents.map((item) => item.key)).toEqual(["u2", "u3"]);
+    expect(second.cursor).toBeNull();
   });
 
   test("migration lock/checkpoint/status semantics", async () => {

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { dynamoDbEngine } from "../../src/engines/dynamodb";
 import { firestoreEngine } from "../../src/engines/firestore";
 import { mongoDbEngine } from "../../src/engines/mongodb";
+import { encodeQueryPageCursor } from "../../src/engines/query-cursor";
 
 type AnyRecord = Record<string, unknown>;
 
@@ -439,29 +440,119 @@ describe("non-SQL query pushdown", () => {
     });
     expect(mongoDocs.lastLimit).toBe(3);
     expect(result.documents.map((doc) => doc.key)).toEqual(["u1", "u2"]);
-    expect(result.cursor).toBe("u2");
+    expect(result.cursor).toBe(
+      encodeQueryPageCursor(
+        "users",
+        {
+          index: "byEmail",
+          filter: { value: { $gte: "a@example.com" } },
+          sort: "asc",
+          limit: 2,
+        },
+        {
+          key: "u2",
+          createdAt: 2,
+          indexValue: "b@example.com",
+        },
+      ),
+    );
   });
 
   test("mongodb query pushes cursor pagination when cursor matches filter", async () => {
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
     });
+    const cursor = encodeQueryPageCursor(
+      "users",
+      {
+        index: "byEmail",
+        filter: { value: { $gte: "a@example.com" } },
+        sort: "asc",
+      },
+      {
+        key: "u1",
+        createdAt: 1,
+        indexValue: "a@example.com",
+      },
+    );
 
     const result = await engine.query("users", {
       index: "byEmail",
       filter: { value: { $gte: "a@example.com" } },
       sort: "asc",
-      cursor: "u1",
+      cursor,
       limit: 1,
     });
 
-    expect(mongoDocs.findOneCalls).toContainEqual({
-      collection: "users",
-      key: "u1",
-    });
+    expect(mongoDocs.findOneCalls).toHaveLength(0);
     expect(mongoDocs.lastFindFilter && "$or" in mongoDocs.lastFindFilter).toBe(true);
     expect(result.documents.map((doc) => doc.key)).toEqual(["u2"]);
-    expect(result.cursor).toBe("u2");
+    expect(result.cursor).toBe(
+      encodeQueryPageCursor(
+        "users",
+        {
+          index: "byEmail",
+          filter: { value: { $gte: "a@example.com" } },
+          sort: "asc",
+          limit: 1,
+        },
+        {
+          key: "u2",
+          createdAt: 2,
+          indexValue: "b@example.com",
+        },
+      ),
+    );
+  });
+
+  test("mongodb query paginates from opaque cursor after cursor row is deleted", async () => {
+    mongoDocs = new FakeMongoCollection([
+      makeEngineDoc("u2", 2, { byEmail: "b@example.com" }, { id: "u2" }),
+      makeEngineDoc("u3", 3, { byEmail: "c@example.com" }, { id: "u3" }),
+    ]);
+
+    const engine = mongoDbEngine({
+      database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+    });
+    const cursor = encodeQueryPageCursor(
+      "users",
+      {
+        index: "byEmail",
+        filter: { value: { $gte: "a@example.com" } },
+        sort: "asc",
+      },
+      {
+        key: "u1",
+        createdAt: 1,
+        indexValue: "a@example.com",
+      },
+    );
+
+    const result = await engine.query("users", {
+      index: "byEmail",
+      filter: { value: { $gte: "a@example.com" } },
+      sort: "asc",
+      cursor,
+      limit: 1,
+    });
+
+    expect(result.documents.map((doc) => doc.key)).toEqual(["u2"]);
+  });
+
+  test("mongodb query rejects raw key cursors for native pagination", async () => {
+    const engine = mongoDbEngine({
+      database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+    });
+
+    expect(
+      engine.query("users", {
+        index: "byEmail",
+        filter: { value: { $gte: "a@example.com" } },
+        sort: "asc",
+        cursor: "u1",
+        limit: 1,
+      }),
+    ).rejects.toThrow(/cursor/i);
   });
 
   test("mongodb query pushes combined between/range filters to backend", async () => {
@@ -672,7 +763,22 @@ describe("non-SQL query pushdown", () => {
     });
 
     expect(first.documents.map((doc) => doc.key)).toEqual(["u2"]);
-    expect(first.cursor).toBe("u2");
+    expect(first.cursor).toBe(
+      encodeQueryPageCursor(
+        "users",
+        {
+          index: "byEmail",
+          filter: { value: { $between: ["a@example.com", "c@example.com"], $gt: "a@example.com" } },
+          sort: "asc",
+          limit: 1,
+        },
+        {
+          key: "u2",
+          createdAt: 2,
+          indexValue: "b@example.com",
+        },
+      ),
+    );
     expect(second.documents.map((doc) => doc.key)).toEqual(["u3"]);
     expect(second.cursor).toBeNull();
   });

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -539,12 +539,12 @@ describe("non-SQL query pushdown", () => {
     expect(result.documents.map((doc) => doc.key)).toEqual(["u2"]);
   });
 
-  test("mongodb query rejects raw key cursors for native pagination", async () => {
+  test("mongodb query rejects raw key cursors for native pagination", () => {
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
     });
 
-    expect(
+    return expect(
       engine.query("users", {
         index: "byEmail",
         filter: { value: { $gte: "a@example.com" } },


### PR DESCRIPTION
## Summary
- switch MongoDB query pagination to the shared opaque, query-bound cursor helpers in both native and fallback execution paths
- derive native MongoDB pagination predicates from decoded cursor positions instead of re-reading raw document keys
- add MongoDB regression coverage for opaque cursor encoding, raw-key cursor rejection, query-bound validation, deleted-cursor-row resume behavior, and include a patch changeset

## Root Cause
MongoDB query pagination still treated `params.cursor` as a raw document key and returned raw keys as the next cursor. That bypassed the shared cursor signature/version contract and made MongoDB pagination semantics diverge from the other adapters.

## Impact
MongoDB pagination now matches the shared cross-engine cursor contract. Cursors are opaque, query-bound, and continue correctly even if the cursor row is deleted before the next page request.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bun test ./tests/unit/non-sql-query-pushdown.test.ts`
- `bun run services:up:mongodb` (blocked: Docker daemon unavailable at `/Users/samuellaycock/.orbstack/run/docker.sock`)

Closes #113