### PR TITLE
[codex] Make MongoDB fallback scans opt in

### DIFF
--- a/.changeset/mongo-scan-opt-in.md
+++ b/.changeset/mongo-scan-opt-in.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": minor
+---
+
+Require MongoDB query fallback collection scans to be explicitly enabled with
+`allowFallbackCollectionScans`, while keeping `rejectUnsupportedQueries` as an
+optional stricter guard when scan fallback is enabled.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,10 @@ await client.connect();
 
 const engine = mongoDbEngine({
   database: client.db("app"),
-  // Optional: fail fast when an indexed filter cannot be pushed down.
+  // Optional: explicitly permit in-memory collection-scan fallback behavior.
+  allowFallbackCollectionScans: true,
+  // Optional: still fail fast on unsupported indexed filters even when
+  // collection-scan fallback is enabled.
   rejectUnsupportedQueries: true,
   // Optional: telemetry hook for in-memory scan fallback usage.
   onQueryFallbackScan(event) {
@@ -329,8 +332,10 @@ Document migration metadata used for outdated-page queries is co-located with ea
 `nosql_odm_metadata` stores migration lock/checkpoint/sequence state.
 
 You can override collection names with `documentsCollection` / `metadataCollection`.
-Set `rejectUnsupportedQueries: true` to throw on unsupported indexed filters instead of silently
-running an in-memory collection scan. Use `onQueryFallbackScan` to instrument fallback scans.
+MongoDB collection-scan fallback is disabled by default. Set
+`allowFallbackCollectionScans: true` to opt into the previous in-memory scan behavior when no
+native query plan is available, and add `rejectUnsupportedQueries: true` if unsupported indexed
+filters should still fail fast. Use `onQueryFallbackScan` to instrument fallback scans.
 
 ## MySQL Engine (`mysql2`)
 

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -91,8 +91,14 @@ export interface MongoDbEngineOptions {
   documentsCollection?: string;
   metadataCollection?: string;
   /**
+   * When true, query/queryWithMetadata may fall back to an in-memory
+   * collection scan when a native MongoDB plan is unavailable.
+   */
+  allowFallbackCollectionScans?: boolean;
+  /**
    * When true, indexed queries with unsupported filter operators throw instead
-   * of silently falling back to an in-memory collection scan.
+   * of using the in-memory collection scan fallback, even when fallback scans
+   * are enabled.
    */
   rejectUnsupportedQueries?: boolean;
   /**
@@ -157,6 +163,7 @@ interface OutdatedCursorState {
 
 export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine {
   const database = options.database;
+  const allowFallbackCollectionScans = options.allowFallbackCollectionScans === true;
   const rejectUnsupportedQueries = options.rejectUnsupportedQueries === true;
   const onQueryFallbackScan = options.onQueryFallbackScan;
   const documentsCollection = database.collection(
@@ -329,6 +336,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
       }
 
       handleMongoQueryFallback({
+        allowFallbackCollectionScans,
         collection,
         params,
         operation: "query",
@@ -354,6 +362,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
       }
 
       handleMongoQueryFallback({
+        allowFallbackCollectionScans,
         collection,
         params,
         operation: "queryWithMetadata",
@@ -1000,6 +1009,7 @@ type MongoIndexFilterResolution =
     };
 
 interface HandleMongoQueryFallbackParams {
+  allowFallbackCollectionScans: boolean;
   collection: string;
   params: QueryParams;
   operation: "query" | "queryWithMetadata";
@@ -1020,6 +1030,10 @@ function handleMongoQueryFallback(params: HandleMongoQueryFallbackParams): void 
     console.error("[nosql-odm] onQueryFallbackScan threw", error);
   }
 
+  if (!params.allowFallbackCollectionScans) {
+    throw createMongoQueryFallbackError(params);
+  }
+
   if (params.reason === "unsupported_filter" && params.rejectUnsupportedQueries) {
     throw new Error(
       `MongoDB cannot push down unsupported query filters for index "${
@@ -1027,6 +1041,20 @@ function handleMongoQueryFallback(params: HandleMongoQueryFallbackParams): void 
       }"`,
     );
   }
+}
+
+function createMongoQueryFallbackError(params: HandleMongoQueryFallbackParams): Error {
+  if (params.reason === "unsupported_filter") {
+    return new Error(
+      `MongoDB cannot push down unsupported query filters for index "${
+        params.params.index ?? "(unknown)"
+      }". Set allowFallbackCollectionScans: true to permit an in-memory collection scan.`,
+    );
+  }
+
+  return new Error(
+    `MongoDB query requires allowFallbackCollectionScans: true to permit an in-memory collection scan for collection "${params.collection}"`,
+  );
 }
 
 function resolveMongoNativeQueryPlan(

--- a/tests/integration/mongodb-engine.test.ts
+++ b/tests/integration/mongodb-engine.test.ts
@@ -123,6 +123,7 @@ describe("mongoDbEngine integration", () => {
     collection = nextCollection("users");
     engine = mongoDbEngine({
       database: requireDatabase(),
+      allowFallbackCollectionScans: true,
     });
   });
 
@@ -496,7 +497,7 @@ describe("mongoDbEngine integration", () => {
     expect(second.cursor).toBeNull();
   });
 
-  test("query supports comparison filters and scan behavior", async () => {
+  test("query supports comparison filters and explicit scan behavior", async () => {
     await engine.put(collection, "u1", { id: "u1" }, { byScore: "001" });
     await engine.put(collection, "u2", { id: "u2" }, { byScore: "010" });
     await engine.put(collection, "u3", { id: "u3" }, { byScore: "020" });
@@ -519,6 +520,19 @@ describe("mongoDbEngine integration", () => {
     expect(range.documents.map((item) => item.key)).toEqual(["u2"]);
     expect(between.documents.map((item) => item.key)).toEqual(["u2", "u3"]);
     expect(scan.documents).toHaveLength(3);
+  });
+
+  test("query rejects collection scans by default unless explicitly enabled", async () => {
+    const strictEngine = mongoDbEngine({
+      database: requireDatabase(),
+    });
+
+    await strictEngine.put(collection, "u1", { id: "u1" }, { byScore: "001" });
+
+    await expectReject(
+      strictEngine.query(collection, {}),
+      /allowFallbackCollectionScans|collection scan/i,
+    );
   });
 
   test("query pagination edge cases", async () => {

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -678,10 +678,9 @@ describe("non-SQL query pushdown", () => {
     expect(result.documents).toEqual([]);
   });
 
-  test("mongodb query can reject unsupported filters instead of scanning", async () => {
+  test("mongodb query rejects unsupported filters by default instead of scanning", async () => {
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
-      rejectUnsupportedQueries: true,
     } as Parameters<typeof mongoDbEngine>[0]);
     let error: unknown = null;
 
@@ -700,10 +699,28 @@ describe("non-SQL query pushdown", () => {
     expect(mongoDocs.lastFindFilter).toBeNull();
   });
 
-  test("mongodb query reports fallback scans with a hook", async () => {
+  test("mongodb query rejects full scans by default", async () => {
+    const engine = mongoDbEngine({
+      database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+    } as Parameters<typeof mongoDbEngine>[0]);
+    let error: unknown = null;
+
+    try {
+      await engine.query("users", {});
+    } catch (candidate) {
+      error = candidate;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/allowFallbackCollectionScans|collection scan/i);
+    expect(mongoDocs.lastFindFilter).toBeNull();
+  });
+
+  test("mongodb query can opt into unsupported-filter fallback scans with a hook", async () => {
     const events: Array<Record<string, unknown>> = [];
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+      allowFallbackCollectionScans: true,
       onQueryFallbackScan(event) {
         events.push(event as unknown as Record<string, unknown>);
       },
@@ -723,10 +740,11 @@ describe("non-SQL query pushdown", () => {
     });
   });
 
-  test("mongodb query reports full_scan fallback with a hook when no index is provided", async () => {
+  test("mongodb query reports full_scan fallback with a hook when explicitly enabled", async () => {
     const events: Array<Record<string, unknown>> = [];
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+      allowFallbackCollectionScans: true,
       onQueryFallbackScan(event) {
         events.push(event as unknown as Record<string, unknown>);
       },
@@ -740,6 +758,9 @@ describe("non-SQL query pushdown", () => {
       collection: "users",
       operation: "query",
       reason: "full_scan",
+    });
+    expect(mongoDocs.lastFindFilter).toEqual({
+      collection: "users",
     });
   });
 
@@ -787,6 +808,7 @@ describe("non-SQL query pushdown", () => {
     const events: Array<Record<string, unknown>> = [];
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+      allowFallbackCollectionScans: true,
       onQueryFallbackScan(event) {
         events.push(event as unknown as Record<string, unknown>);
       },
@@ -809,6 +831,28 @@ describe("non-SQL query pushdown", () => {
     });
   });
 
+  test("mongodb query can reject unsupported filters even when fallback scans are enabled", async () => {
+    const engine = mongoDbEngine({
+      database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+      allowFallbackCollectionScans: true,
+      rejectUnsupportedQueries: true,
+    } as Parameters<typeof mongoDbEngine>[0]);
+    let error: unknown = null;
+
+    try {
+      await engine.query("users", {
+        index: "byEmail",
+        filter: { value: { $foo: "bar" } as unknown as Record<string, unknown> },
+      });
+    } catch (candidate) {
+      error = candidate;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/unsupported/i);
+    expect(mongoDocs.lastFindFilter).toBeNull();
+  });
+
   test("mongodb fallback hook errors do not suppress rejectUnsupportedQueries errors", async () => {
     const originalConsoleError = console.error;
     const logged: unknown[][] = [];
@@ -817,6 +861,7 @@ describe("non-SQL query pushdown", () => {
     };
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+      allowFallbackCollectionScans: true,
       rejectUnsupportedQueries: true,
       onQueryFallbackScan() {
         throw new Error("hook failure");


### PR DESCRIPTION
## Summary
- disable MongoDB in-memory query fallback scans by default when no native plan is available
- add `allowFallbackCollectionScans` as the explicit compatibility flag for the previous fallback behavior
- keep `rejectUnsupportedQueries` available as a stricter guard when fallback scans are explicitly enabled
- document the new behavior and add regression coverage for strict default and opt-in fallback paths

## Why
Issue #114 called out that MongoDB queries could silently degrade into O(collection) scans whenever a query could not be pushed down natively. That made performance characteristics unstable and hid the fallback behind implicit adapter behavior.

## Root Cause
`mongoDbEngine()` treated any non-native query plan as eligible for `listCollectionDocuments()` unless `rejectUnsupportedQueries` was enabled, and that guard only applied to unsupported indexed filters. Full scans and unsupported filters therefore fell back to in-memory scans by default.

## Impact
MongoDB query fallback scans are now explicit instead of implicit. Consumers who still want the old compatibility behavior can opt back in with `allowFallbackCollectionScans: true`. Consumers who want that compatibility but still want unsupported indexed filters to fail can combine it with `rejectUnsupportedQueries: true`.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`
- `bun run services:up:mongodb && bun run test:integration:mongodb && bun run services:down:mongodb` could not be completed locally because Docker was not running (`Cannot connect to the Docker daemon at unix:///Users/samuellaycock/.orbstack/run/docker.sock`)

Closes #114