### PR TITLE
[codex] Strengthen query cursor conformance coverage

### DIFF
--- a/.changeset/cursor-conformance.md
+++ b/.changeset/cursor-conformance.md
@@ -1,0 +1,6 @@
+---
+"nosql-odm": patch
+---
+
+Strengthen shared query cursor conformance coverage for opaque payloads,
+query-bound reuse checks, and deleted-row resume behavior across adapters.

--- a/tests/integration/conformance-suite.ts
+++ b/tests/integration/conformance-suite.ts
@@ -3,11 +3,27 @@ import { describe, expect, test } from "bun:test";
 import { EngineUniqueConstraintError, type QueryEngine } from "../../src/engines/types";
 import { expectRejectInstanceOf } from "./helpers";
 
+interface DecodedQueryCursorPayload {
+  readonly kind: "nosql-odm-query-cursor";
+  readonly version: number;
+  readonly signature: string;
+  readonly position: {
+    readonly kind: string;
+    readonly key: string;
+    readonly createdAt?: number;
+    readonly indexValue?: string;
+  };
+}
+
 interface QueryEngineConformanceSuiteOptions<TOptions = Record<string, unknown>> {
   readonly engineName: string;
   readonly getEngine: () => QueryEngine<TOptions>;
   readonly nextCollection: (prefix: string) => string;
   readonly assertEngineUniqueConstraintConformance?: boolean;
+}
+
+function decodeQueryCursor(cursor: string): DecodedQueryCursorPayload {
+  return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")) as DecodedQueryCursorPayload;
 }
 
 export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown>>(
@@ -138,6 +154,72 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
       expect(page1.cursor).not.toBeNull();
       expect(page2.documents).toHaveLength(1);
       expect(page2.cursor).toBeNull();
+    });
+
+    test("uses opaque, query-bound cursors that resume correctly after cursor row deletion", async () => {
+      const engine = getEngine();
+      const collection = nextCollection("cursor_users");
+
+      await engine.batchSet(collection, [
+        { key: "u1", doc: { id: "u1" }, indexes: { status: "active" } },
+        { key: "u2", doc: { id: "u2" }, indexes: { status: "active" } },
+        { key: "u3", doc: { id: "u3" }, indexes: { status: "active" } },
+        { key: "u4", doc: { id: "u4" }, indexes: { status: "inactive" } },
+      ]);
+
+      const firstPage = await engine.query(collection, {
+        index: "status",
+        filter: { value: "active" },
+        limit: 2,
+      });
+      const cursor = firstPage.cursor;
+
+      expect(firstPage.documents).toHaveLength(2);
+      expect(cursor).not.toBeNull();
+
+      const decodedCursor = decodeQueryCursor(cursor!);
+      const cursorKey = firstPage.documents[firstPage.documents.length - 1]!.key;
+
+      expect(decodedCursor).toMatchObject({
+        kind: "nosql-odm-query-cursor",
+        position: {
+          kind: "scan",
+          key: cursorKey,
+        },
+      });
+      expect(decodedCursor.signature.length).toBeGreaterThan(0);
+      expect(typeof decodedCursor.position.createdAt).toBe("number");
+
+      let mismatchError: unknown = null;
+
+      try {
+        await engine.query(collection, {
+          index: "status",
+          filter: { value: "inactive" },
+          limit: 2,
+          cursor: cursor!,
+        });
+      } catch (error) {
+        mismatchError = error;
+      }
+
+      expect(mismatchError).toBeInstanceOf(Error);
+      expect((mismatchError as Error).message).toBe(
+        "Query cursor does not match the requested query",
+      );
+
+      await engine.delete(collection, cursorKey);
+
+      const secondPage = await engine.query(collection, {
+        index: "status",
+        filter: { value: "active" },
+        limit: 2,
+        cursor: cursor!,
+      });
+
+      expect(secondPage.documents).toHaveLength(1);
+      expect(secondPage.documents[0]?.key).not.toBe(cursorKey);
+      expect(secondPage.cursor).toBeNull();
     });
 
     uniqueConstraintConformanceTest(

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -555,6 +555,45 @@ describe("non-SQL query pushdown", () => {
     ).rejects.toThrow(/cursor/i);
   });
 
+  test("mongodb query rejects opaque cursors reused with a different query", async () => {
+    const engine = mongoDbEngine({
+      database: new FakeMongoDatabase(mongoDocs, mongoMeta),
+    });
+    const cursor = encodeQueryPageCursor(
+      "users",
+      {
+        index: "byEmail",
+        filter: { value: { $gte: "a@example.com" } },
+        sort: "asc",
+      },
+      {
+        key: "u1",
+        createdAt: 1,
+        indexValue: "a@example.com",
+      },
+    );
+
+    let error: unknown = null;
+
+    try {
+      await engine.query("users", {
+        index: "byEmail",
+        filter: { value: { $gte: "b@example.com" } },
+        sort: "asc",
+        cursor,
+        limit: 1,
+      });
+    } catch (candidate) {
+      error = candidate;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Query cursor does not match the requested query");
+
+    expect(mongoDocs.lastFindFilter).toBeNull();
+    expect(mongoDocs.findOneCalls).toHaveLength(0);
+  });
+
   test("mongodb query pushes combined between/range filters to backend", async () => {
     const engine = mongoDbEngine({
       database: new FakeMongoDatabase(mongoDocs, mongoMeta),


### PR DESCRIPTION
## Summary
- strengthen the shared integration conformance suite to assert opaque cursor payloads instead of only page counts
- enforce that paginated equality queries reject cross-query cursor reuse and resume correctly after the cursor row is deleted
- add MongoDB native query pushdown coverage for rejecting opaque cursors reused against a different query shape

## Why
Issue #115 identified that the conformance suite was not enforcing the shared query cursor contract strongly enough. Adapters could drift from the shared opaque, query-bound cursor semantics while still passing the existing integration coverage.

## Root Cause
The existing conformance test only verified that pagination advanced between pages. It did not assert the actual cursor payload shape, did not prove cursors were bound to the originating query, and did not verify resume behavior after the cursor row disappeared.

## Impact
This tightens regression coverage around pagination semantics shared across adapters, making adapter drift easier to catch before release. The MongoDB pushdown unit test also verifies that mismatched opaque cursors are rejected before any backend query is issued.

## Validation
- `bun fmt`
- `bun lint:fix` (passes with 4 pre-existing warnings in unrelated files)
- `bun run test`
- `bun typecheck`
- `bun test tests/integration/memory-engine.test.ts`
- `bun test tests/integration/indexeddb-engine.test.ts`
- `bun test tests/integration/sqlite-engine.test.ts`
- `bun test tests/unit/non-sql-query-pushdown.test.ts`

## Notes
- `bun run services:up:mongodb` could not be run in this environment because Docker was unavailable (`Cannot connect to the Docker daemon at unix:///Users/samuellaycock/.orbstack/run/docker.sock`).

Closes #115