### PR TITLE
[codex] fix(dynamodb): push down indexed queries via query index

### DIFF
--- a/.changeset/dynamodb-query-index-pushdown.md
+++ b/.changeset/dynamodb-query-index-pushdown.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Replace DynamoDB index-filter partition scans with query-index lookups when an
+index-backed filter can be pushed down, while preserving scan fallback when the
+secondary lookup index is unavailable.

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -10,6 +10,7 @@ import {
   type BatchGetCommandInput,
   type BatchWriteCommandInput,
   type QueryCommandInput,
+  type TransactWriteCommandInput,
 } from "@aws-sdk/lib-dynamodb";
 
 import { DefaultMigrator } from "../migrator";
@@ -37,9 +38,11 @@ const META_PARTITION_KEY = "META";
 const OUTDATED_PAGE_LIMIT = 100;
 const METADATA_SYNC_CHUNK_SIZE = 100;
 const ITEM_TYPE_DOC = "doc";
+const ITEM_TYPE_QUERY_INDEX = "query_index";
 const ITEM_TYPE_LOCK = "lock";
 const ITEM_TYPE_CHECKPOINT = "checkpoint";
 const ITEM_TYPE_MIGRATION_METADATA = "migration_metadata";
+const QUERY_INDEX = "query_idx";
 const MIGRATION_OUTDATED_INDEX = "migration_outdated_idx";
 const MIGRATION_SYNC_INDEX = "migration_sync_idx";
 const MIGRATION_OUTDATED_KEY_PREFIX = "SIG#";
@@ -54,6 +57,7 @@ export interface DynamoDbEngineOptions {
   tableName: string;
   hashKeyName?: string;
   sortKeyName?: string;
+  queryIndexName?: string;
   migrationOutdatedIndexName?: string;
   migrationSyncIndexName?: string;
 }
@@ -63,6 +67,7 @@ export interface DynamoDbQueryEngine extends QueryEngine<never> {}
 interface DynamoKeyConfig {
   hashKeyName: string;
   sortKeyName: string;
+  queryIndexName: string;
   migrationOutdatedIndexName: string;
   migrationSyncIndexName: string;
 }
@@ -82,6 +87,19 @@ interface StoredDocumentItem {
   writeVersion: number;
   doc: Record<string, unknown>;
   indexes: ResolvedIndexKeys;
+}
+
+interface QueryIndexItem {
+  pk: string;
+  sk: string;
+  itemType: typeof ITEM_TYPE_QUERY_INDEX;
+  collection: string;
+  key: string;
+  indexName: string;
+  indexValue: string;
+  createdAt: number;
+  queryPk: string;
+  querySk: string;
 }
 
 interface LockItem {
@@ -132,10 +150,16 @@ interface OutdatedCursorState {
 type BatchWriteRequest = NonNullable<
   NonNullable<BatchWriteCommandInput["RequestItems"]>[string]
 >[number];
+type TransactWriteItem = NonNullable<TransactWriteCommandInput["TransactItems"]>[number];
 
 function normalizeKeyConfig(options: DynamoDbEngineOptions): DynamoKeyConfig {
   const hashKeyName = normalizeNonEmptyString(options.hashKeyName, "pk", "hashKeyName");
   const sortKeyName = normalizeNonEmptyString(options.sortKeyName, "sk", "sortKeyName");
+  const queryIndexName = normalizeNonEmptyString(
+    options.queryIndexName,
+    QUERY_INDEX,
+    "queryIndexName",
+  );
   const migrationOutdatedIndexName = normalizeNonEmptyString(
     options.migrationOutdatedIndexName,
     MIGRATION_OUTDATED_INDEX,
@@ -154,6 +178,7 @@ function normalizeKeyConfig(options: DynamoDbEngineOptions): DynamoKeyConfig {
   return {
     hashKeyName,
     sortKeyName,
+    queryIndexName,
     migrationOutdatedIndexName,
     migrationSyncIndexName,
   };
@@ -251,14 +276,24 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
     async create(collection, key, doc, indexes, _options, migrationMetadata) {
       const createdAt = await nextSequence(client, tableName, keyConfig, collection);
       const item = createDocumentItem(collection, key, createdAt, 1, doc, indexes);
+      const queryIndexItems = createQueryIndexItems(collection, key, createdAt, indexes);
       const metadata =
         normalizeMigrationMetadata(migrationMetadata) ?? deriveLegacyMetadataFromDocument(doc);
       const metadataItem = createMigrationMetadataItem(collection, key, metadata);
 
       try {
-        await putDocumentAndMetadata(client, tableName, keyConfig, item, metadataItem, {
-          requireDocumentToNotExist: true,
-        });
+        await putDocumentAndMetadata(
+          client,
+          tableName,
+          keyConfig,
+          item,
+          metadataItem,
+          queryIndexItems,
+          [],
+          {
+            requireDocumentToNotExist: true,
+          },
+        );
       } catch (error) {
         if (isConditionalCheckFailed(error) || isTransactionConditionalCheckFailed(error)) {
           throw new EngineDocumentAlreadyExistsError(collection, key);
@@ -274,11 +309,20 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
         existing?.createdAt ?? (await nextSequence(client, tableName, keyConfig, collection));
       const writeVersion = (existing?.writeVersion ?? 0) + 1;
       const item = createDocumentItem(collection, key, createdAt, writeVersion, doc, indexes);
+      const queryIndexItems = createQueryIndexItems(collection, key, createdAt, indexes);
       const metadata =
         normalizeMigrationMetadata(migrationMetadata) ?? deriveLegacyMetadataFromDocument(doc);
       const metadataItem = createMigrationMetadataItem(collection, key, metadata);
 
-      await putDocumentAndMetadata(client, tableName, keyConfig, item, metadataItem);
+      await putDocumentAndMetadata(
+        client,
+        tableName,
+        keyConfig,
+        item,
+        metadataItem,
+        queryIndexItems,
+        diffRemovedIndexNames(existing?.indexes, indexes),
+      );
     },
 
     async update(collection, key, doc, indexes, _options, migrationMetadata) {
@@ -296,14 +340,24 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
         doc,
         indexes,
       );
+      const queryIndexItems = createQueryIndexItems(collection, key, existing.createdAt, indexes);
       const metadata =
         normalizeMigrationMetadata(migrationMetadata) ?? deriveLegacyMetadataFromDocument(doc);
       const metadataItem = createMigrationMetadataItem(collection, key, metadata);
 
       try {
-        await putDocumentAndMetadata(client, tableName, keyConfig, item, metadataItem, {
-          requireDocumentToExist: true,
-        });
+        await putDocumentAndMetadata(
+          client,
+          tableName,
+          keyConfig,
+          item,
+          metadataItem,
+          queryIndexItems,
+          diffRemovedIndexNames(existing.indexes, indexes),
+          {
+            requireDocumentToExist: true,
+          },
+        );
       } catch (error) {
         if (isConditionalCheckFailed(error) || isTransactionConditionalCheckFailed(error)) {
           throw new EngineDocumentNotFoundError(collection, key);
@@ -314,7 +368,15 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
     },
 
     async delete(collection, key) {
-      await deleteDocumentAndMetadata(client, tableName, keyConfig, collection, key);
+      const existing = await getDocumentItem(client, tableName, keyConfig, collection, key);
+      await deleteDocumentAndMetadata(
+        client,
+        tableName,
+        keyConfig,
+        collection,
+        key,
+        existing ? Object.keys(existing.indexes) : [],
+      );
     },
 
     async query(collection, params) {
@@ -379,6 +441,8 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
       const writes: Array<{
         docItem: StoredDocumentItem;
         metadataItem: MigrationMetadataItem;
+        queryIndexItems: QueryIndexItem[];
+        removedIndexNames: string[];
       }> = [];
 
       for (const item of items) {
@@ -401,6 +465,8 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
             item.indexes,
           ),
           metadataItem: createMigrationMetadataItem(collection, item.key, metadata),
+          queryIndexItems: createQueryIndexItems(collection, item.key, createdAt, item.indexes),
+          removedIndexNames: diffRemovedIndexNames(existingRecord?.indexes, item.indexes),
         });
       }
 
@@ -435,11 +501,26 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
             item.doc,
             item.indexes,
           );
+          const queryIndexItems = createQueryIndexItems(
+            collection,
+            item.key,
+            existingRecord.createdAt,
+            item.indexes,
+          );
 
           try {
-            await putDocumentAndMetadata(client, tableName, keyConfig, docItem, metadataItem, {
-              expectedWriteVersion,
-            });
+            await putDocumentAndMetadata(
+              client,
+              tableName,
+              keyConfig,
+              docItem,
+              metadataItem,
+              queryIndexItems,
+              diffRemovedIndexNames(existingRecord.indexes, item.indexes),
+              {
+                expectedWriteVersion,
+              },
+            );
             persistedKeys.push(item.key);
           } catch (error) {
             if (isConditionalCheckFailed(error) || isTransactionConditionalCheckFailed(error)) {
@@ -465,7 +546,15 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
           item.doc,
           item.indexes,
         );
-        await putDocumentAndMetadata(client, tableName, keyConfig, docItem, metadataItem);
+        await putDocumentAndMetadata(
+          client,
+          tableName,
+          keyConfig,
+          docItem,
+          metadataItem,
+          createQueryIndexItems(collection, item.key, createdAt, item.indexes),
+          diffRemovedIndexNames(existingRecord?.indexes, item.indexes),
+        );
         persistedKeys.push(item.key);
       }
 
@@ -476,7 +565,15 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
     },
 
     async batchDelete(collection, keys) {
-      await deleteDocumentAndMetadataBatch(client, tableName, keyConfig, collection, keys);
+      const existing = await batchGetDocuments(client, tableName, keyConfig, collection, keys);
+      await deleteDocumentAndMetadataBatch(
+        client,
+        tableName,
+        keyConfig,
+        collection,
+        keys,
+        existing,
+      );
     },
 
     migration: {
@@ -689,6 +786,18 @@ function metadataSortKey(key: string): string {
   return `META#${key}`;
 }
 
+function queryIndexItemSortKey(indexName: string, key: string): string {
+  return `QIDX#${encodeComparableComponent(indexName)}#${encodeComparableComponent(key)}`;
+}
+
+function queryIndexPartitionKey(collection: string, indexName: string): string {
+  return `QIDX#COL#${collection}#IDX#${encodeComparableComponent(indexName)}`;
+}
+
+function queryIndexSortKey(indexValue: string, createdAt: number, key: string): string {
+  return `${encodeComparableComponent(indexValue)}#${padCreatedAt(createdAt)}#${encodeComparableComponent(key)}`;
+}
+
 function migrationOutdatedPartitionKey(
   collection: string,
   targetVersion: number,
@@ -699,6 +808,14 @@ function migrationOutdatedPartitionKey(
 
 function migrationSyncPartitionKey(collection: string): string {
   return `MIGSYNC#${collection}`;
+}
+
+function encodeComparableComponent(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+function padCreatedAt(value: number): string {
+  return String(value).padStart(16, "0");
 }
 
 function parseDocumentItem(value: unknown, keyConfig: DynamoKeyConfig): StoredDocumentItem {
@@ -754,6 +871,52 @@ function parseDocumentItem(value: unknown, keyConfig: DynamoKeyConfig): StoredDo
     writeVersion,
     doc: doc as Record<string, unknown>,
     indexes: resolvedIndexes,
+  };
+}
+
+function parseQueryIndexItem(value: unknown, keyConfig: DynamoKeyConfig): QueryIndexItem {
+  if (!isRecord(value)) {
+    throw new Error("DynamoDB returned an invalid query index item");
+  }
+
+  const pk = value[keyConfig.hashKeyName];
+  const sk = value[keyConfig.sortKeyName];
+  const itemType = value.itemType;
+  const collection = value.collection;
+  const key = value.key;
+  const indexName = value.indexName;
+  const indexValue = value.indexValue;
+  const createdAt = value.createdAt;
+  const queryPk = value.queryPk;
+  const querySk = value.querySk;
+
+  if (
+    typeof pk !== "string" ||
+    typeof sk !== "string" ||
+    itemType !== ITEM_TYPE_QUERY_INDEX ||
+    typeof collection !== "string" ||
+    typeof key !== "string" ||
+    typeof indexName !== "string" ||
+    typeof indexValue !== "string" ||
+    typeof createdAt !== "number" ||
+    !Number.isFinite(createdAt) ||
+    typeof queryPk !== "string" ||
+    typeof querySk !== "string"
+  ) {
+    throw new Error("DynamoDB returned an invalid query index item");
+  }
+
+  return {
+    pk,
+    sk,
+    itemType,
+    collection,
+    key,
+    indexName,
+    indexValue,
+    createdAt,
+    queryPk,
+    querySk,
   };
 }
 
@@ -928,6 +1091,38 @@ function createDocumentItem(
   };
 }
 
+function createQueryIndexItems(
+  collection: string,
+  key: string,
+  createdAt: number,
+  indexes: ResolvedIndexKeys,
+): QueryIndexItem[] {
+  return Object.entries(indexes).map(([indexName, indexValue]) =>
+    createQueryIndexItem(collection, key, createdAt, indexName, indexValue),
+  );
+}
+
+function createQueryIndexItem(
+  collection: string,
+  key: string,
+  createdAt: number,
+  indexName: string,
+  indexValue: string,
+): QueryIndexItem {
+  return {
+    pk: collectionPartitionKey(collection),
+    sk: queryIndexItemSortKey(indexName, key),
+    itemType: ITEM_TYPE_QUERY_INDEX,
+    collection,
+    key,
+    indexName,
+    indexValue,
+    createdAt,
+    queryPk: queryIndexPartitionKey(collection, indexName),
+    querySk: queryIndexSortKey(indexValue, createdAt, key),
+  };
+}
+
 function createMigrationMetadataItem(
   collection: string,
   key: string,
@@ -1064,12 +1259,102 @@ async function listDocumentsByQuery(
     return null;
   }
 
+  const queryCondition = buildDynamoQueryIndexCondition(
+    collection,
+    params.index,
+    params.filter.value,
+  );
+
+  if (!queryCondition) {
+    return null;
+  }
+
+  try {
+    const matches: QueryIndexItem[] = [];
+    let cursor: Record<string, unknown> | undefined;
+
+    do {
+      const response = (await client.send(
+        new QueryCommand({
+          TableName: tableName,
+          IndexName: keyConfig.queryIndexName,
+          KeyConditionExpression: queryCondition.expression,
+          ExpressionAttributeNames: queryCondition.expressionAttributeNames,
+          ExpressionAttributeValues: queryCondition.expressionAttributeValues,
+          ExclusiveStartKey: cursor,
+        }),
+      )) as {
+        Items?: unknown[];
+        LastEvaluatedKey?: Record<string, unknown>;
+      };
+
+      for (const item of response.Items ?? []) {
+        matches.push(parseQueryIndexItem(item, keyConfig));
+      }
+
+      cursor = response.LastEvaluatedKey;
+    } while (cursor);
+
+    const documents = await batchGetDocuments(
+      client,
+      tableName,
+      keyConfig,
+      collection,
+      matches.map((item) => item.key),
+    );
+    const records: StoredDocumentItem[] = [];
+
+    for (const match of matches) {
+      const record = documents.get(match.key);
+
+      if (!record || record.indexes[match.indexName] !== match.indexValue) {
+        continue;
+      }
+
+      records.push(record);
+    }
+
+    if (!params.sort) {
+      records.sort((a, b) => {
+        if (a.createdAt !== b.createdAt) {
+          return a.createdAt - b.createdAt;
+        }
+
+        return a.key.localeCompare(b.key);
+      });
+    }
+
+    return records;
+  } catch (error) {
+    if (!isMissingDynamoIndexError(error, keyConfig.queryIndexName)) {
+      throw error;
+    }
+  }
+
   const filterExpression = buildDynamoFilterExpression(params.filter.value);
 
   if (!filterExpression) {
     return null;
   }
 
+  return listDocumentsByScanFilter(
+    client,
+    tableName,
+    keyConfig,
+    collection,
+    params.index,
+    filterExpression,
+  );
+}
+
+async function listDocumentsByScanFilter(
+  client: DynamoDbDocumentClientLike,
+  tableName: string,
+  keyConfig: DynamoKeyConfig,
+  collection: string,
+  indexName: string,
+  filterExpression: DynamoFilterExpression,
+): Promise<StoredDocumentItem[]> {
   const pk = collectionPartitionKey(collection);
   const records: StoredDocumentItem[] = [];
   let cursor: Record<string, unknown> | undefined;
@@ -1083,7 +1368,7 @@ async function listDocumentsByQuery(
         "#pk": keyConfig.hashKeyName,
         "#sk": keyConfig.sortKeyName,
         "#indexes": "indexes",
-        "#indexName": params.index,
+        "#indexName": indexName,
         ...filterExpression.expressionAttributeNames,
       },
       ExpressionAttributeValues: {
@@ -1121,6 +1406,159 @@ interface DynamoFilterExpression {
   expression: string;
   expressionAttributeNames: Record<string, string>;
   expressionAttributeValues: Record<string, unknown>;
+}
+
+interface DynamoQueryIndexCondition {
+  expression: string;
+  expressionAttributeNames: Record<string, string>;
+  expressionAttributeValues: Record<string, unknown>;
+}
+
+function buildDynamoQueryIndexCondition(
+  collection: string,
+  indexName: string,
+  filter: string | number | FieldCondition,
+): DynamoQueryIndexCondition | null {
+  const queryPk = queryIndexPartitionKey(collection, indexName);
+  const encodedFieldValue = (value: string | number): string =>
+    encodeComparableComponent(String(value));
+
+  if (typeof filter === "string" || typeof filter === "number") {
+    return {
+      expression: "#queryPk = :queryPk AND begins_with(#querySk, :querySkPrefix)",
+      expressionAttributeNames: {
+        "#queryPk": "queryPk",
+        "#querySk": "querySk",
+      },
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkPrefix": `${encodedFieldValue(filter)}#`,
+      },
+    };
+  }
+
+  const keys = Object.keys(filter);
+
+  if (keys.some((key) => !DYNAMO_SUPPORTED_FILTER_KEYS.has(key))) {
+    return null;
+  }
+
+  const hasEq = filter.$eq !== undefined;
+  const hasBegins = filter.$begins !== undefined;
+  const hasBetween = filter.$between !== undefined;
+  const hasRange =
+    filter.$gt !== undefined ||
+    filter.$gte !== undefined ||
+    filter.$lt !== undefined ||
+    filter.$lte !== undefined;
+
+  if (hasEq && (hasBegins || hasBetween || hasRange)) {
+    return null;
+  }
+
+  if (hasBegins && (hasEq || hasBetween || hasRange)) {
+    return null;
+  }
+
+  if (hasBetween && (hasEq || hasBegins || hasRange)) {
+    return null;
+  }
+
+  if (!hasEq && !hasBegins && !hasBetween && !hasRange) {
+    return null;
+  }
+
+  const expressionAttributeNames = {
+    "#queryPk": "queryPk",
+    "#querySk": "querySk",
+  };
+
+  if (hasEq) {
+    return {
+      expression: "#queryPk = :queryPk AND begins_with(#querySk, :querySkPrefix)",
+      expressionAttributeNames,
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkPrefix": `${encodedFieldValue(filter.$eq as string | number)}#`,
+      },
+    };
+  }
+
+  if (hasBegins) {
+    const beginsValue = filter.$begins;
+
+    if (beginsValue === undefined) {
+      return null;
+    }
+
+    return {
+      expression: "#queryPk = :queryPk AND begins_with(#querySk, :querySkPrefix)",
+      expressionAttributeNames,
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkPrefix": encodedFieldValue(beginsValue),
+      },
+    };
+  }
+
+  if (hasBetween) {
+    const [low, high] = filter.$between as [string | number, string | number];
+
+    return {
+      expression: "#queryPk = :queryPk AND #querySk BETWEEN :querySkLow AND :querySkHigh",
+      expressionAttributeNames,
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkLow": encodedFieldValue(low),
+        ":querySkHigh": `${encodedFieldValue(high)}$`,
+      },
+    };
+  }
+
+  const lowerBound =
+    filter.$gt !== undefined
+      ? `${encodedFieldValue(filter.$gt as string | number)}$`
+      : filter.$gte !== undefined
+        ? encodedFieldValue(filter.$gte as string | number)
+        : undefined;
+  const upperBound =
+    filter.$lt !== undefined
+      ? encodedFieldValue(filter.$lt as string | number)
+      : filter.$lte !== undefined
+        ? `${encodedFieldValue(filter.$lte as string | number)}$`
+        : undefined;
+
+  if (lowerBound !== undefined && upperBound !== undefined) {
+    return {
+      expression: "#queryPk = :queryPk AND #querySk BETWEEN :querySkLow AND :querySkHigh",
+      expressionAttributeNames,
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkLow": lowerBound,
+        ":querySkHigh": upperBound,
+      },
+    };
+  }
+
+  if (lowerBound !== undefined) {
+    return {
+      expression: "#queryPk = :queryPk AND #querySk >= :querySkLow",
+      expressionAttributeNames,
+      expressionAttributeValues: {
+        ":queryPk": queryPk,
+        ":querySkLow": lowerBound,
+      },
+    };
+  }
+
+  return {
+    expression: "#queryPk = :queryPk AND #querySk <= :querySkHigh",
+    expressionAttributeNames,
+    expressionAttributeValues: {
+      ":queryPk": queryPk,
+      ":querySkHigh": upperBound,
+    },
+  };
 }
 
 function buildDynamoFilterExpression(
@@ -1340,6 +1778,8 @@ async function putDocumentAndMetadata(
   keyConfig: DynamoKeyConfig,
   docItem: StoredDocumentItem,
   metadataItem: MigrationMetadataItem,
+  queryIndexItems: QueryIndexItem[],
+  removedIndexNames: string[],
   options?: PutDocumentAndMetadataOptions,
 ): Promise<void> {
   const expressionAttributeNames: Record<string, string> = {};
@@ -1362,31 +1802,45 @@ async function putDocumentAndMetadata(
     conditionExpression = `${conditionExpression ? `${conditionExpression} AND ` : ""}#writeVersion = :expectedWriteVersion`;
   }
 
-  await client.send(
-    new TransactWriteCommand({
-      TransactItems: [
-        {
-          Put: {
-            TableName: tableName,
-            Item: serializeItemForStorage(docItem, keyConfig),
-            ...(conditionExpression ? { ConditionExpression: conditionExpression } : {}),
-            ...(conditionExpression && Object.keys(expressionAttributeNames).length > 0
-              ? { ExpressionAttributeNames: expressionAttributeNames }
-              : {}),
-            ...(conditionExpression && Object.keys(expressionAttributeValues).length > 0
-              ? { ExpressionAttributeValues: expressionAttributeValues }
-              : {}),
-          },
-        },
-        {
-          Put: {
-            TableName: tableName,
-            Item: serializeItemForStorage(metadataItem, keyConfig),
-          },
-        },
-      ],
-    }),
-  );
+  const transactItems: TransactWriteItem[] = [
+    {
+      Put: {
+        TableName: tableName,
+        Item: serializeItemForStorage(docItem, keyConfig),
+        ...(conditionExpression ? { ConditionExpression: conditionExpression } : {}),
+        ...(conditionExpression && Object.keys(expressionAttributeNames).length > 0
+          ? { ExpressionAttributeNames: expressionAttributeNames }
+          : {}),
+        ...(conditionExpression && Object.keys(expressionAttributeValues).length > 0
+          ? { ExpressionAttributeValues: expressionAttributeValues }
+          : {}),
+      },
+    },
+    {
+      Put: {
+        TableName: tableName,
+        Item: serializeItemForStorage(metadataItem, keyConfig),
+      },
+    },
+    ...queryIndexItems.map((item) => ({
+      Put: {
+        TableName: tableName,
+        Item: serializeItemForStorage(item, keyConfig),
+      },
+    })),
+    ...removedIndexNames.map((indexName) => ({
+      Delete: {
+        TableName: tableName,
+        Key: toDynamoPrimaryKey(
+          keyConfig,
+          collectionPartitionKey(docItem.collection),
+          queryIndexItemSortKey(indexName, docItem.key),
+        ),
+      },
+    })),
+  ];
+
+  await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
 }
 
 async function putDocumentAndMetadataBatch(
@@ -1396,36 +1850,54 @@ async function putDocumentAndMetadataBatch(
   writes: Array<{
     docItem: StoredDocumentItem;
     metadataItem: MigrationMetadataItem;
+    queryIndexItems: QueryIndexItem[];
+    removedIndexNames: string[];
   }>,
 ): Promise<void> {
-  for (const chunk of chunkArray(writes, 12)) {
-    const transactItems: Array<{
-      Put: {
-        TableName: string;
-        Item: Record<string, unknown>;
-      };
-    }> = [];
+  let transactItems: TransactWriteItem[] = [];
 
-    for (const entry of chunk) {
-      transactItems.push({
+  for (const entry of writes) {
+    const entryItems: TransactWriteItem[] = [
+      {
         Put: {
           TableName: tableName,
           Item: serializeItemForStorage(entry.docItem, keyConfig),
         },
-      });
-      transactItems.push({
+      },
+      {
         Put: {
           TableName: tableName,
           Item: serializeItemForStorage(entry.metadataItem, keyConfig),
         },
-      });
+      },
+      ...entry.queryIndexItems.map((item) => ({
+        Put: {
+          TableName: tableName,
+          Item: serializeItemForStorage(item, keyConfig),
+        },
+      })),
+      ...entry.removedIndexNames.map((indexName) => ({
+        Delete: {
+          TableName: tableName,
+          Key: toDynamoPrimaryKey(
+            keyConfig,
+            collectionPartitionKey(entry.docItem.collection),
+            queryIndexItemSortKey(indexName, entry.docItem.key),
+          ),
+        },
+      })),
+    ];
+
+    if (transactItems.length > 0 && transactItems.length + entryItems.length > 100) {
+      await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
+      transactItems = [];
     }
 
-    await client.send(
-      new TransactWriteCommand({
-        TransactItems: transactItems,
-      }),
-    );
+    transactItems.push(...entryItems);
+  }
+
+  if (transactItems.length > 0) {
+    await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
   }
 }
 
@@ -1435,6 +1907,7 @@ async function deleteDocumentAndMetadata(
   keyConfig: DynamoKeyConfig,
   collection: string,
   key: string,
+  indexNames: readonly string[],
 ): Promise<void> {
   await client.send(
     new TransactWriteCommand({
@@ -1459,6 +1932,16 @@ async function deleteDocumentAndMetadata(
             ),
           },
         },
+        ...indexNames.map((indexName) => ({
+          Delete: {
+            TableName: tableName,
+            Key: toDynamoPrimaryKey(
+              keyConfig,
+              collectionPartitionKey(collection),
+              queryIndexItemSortKey(indexName, key),
+            ),
+          },
+        })),
       ],
     }),
   );
@@ -1470,21 +1953,15 @@ async function deleteDocumentAndMetadataBatch(
   keyConfig: DynamoKeyConfig,
   collection: string,
   keys: string[],
+  existing: Map<string, StoredDocumentItem>,
 ): Promise<void> {
   const uniqueKeys = uniqueStrings(keys);
 
-  for (const chunk of chunkArray(uniqueKeys, 12)) {
-    const transactItems: Array<{
-      Delete: {
-        TableName: string;
-        Key: {
-          [key: string]: string;
-        };
-      };
-    }> = [];
+  let transactItems: TransactWriteItem[] = [];
 
-    for (const key of chunk) {
-      transactItems.push({
+  for (const key of uniqueKeys) {
+    const entryItems: TransactWriteItem[] = [
+      {
         Delete: {
           TableName: tableName,
           Key: toDynamoPrimaryKey(
@@ -1493,8 +1970,8 @@ async function deleteDocumentAndMetadataBatch(
             documentSortKey(key),
           ),
         },
-      });
-      transactItems.push({
+      },
+      {
         Delete: {
           TableName: tableName,
           Key: toDynamoPrimaryKey(
@@ -1503,14 +1980,29 @@ async function deleteDocumentAndMetadataBatch(
             metadataSortKey(key),
           ),
         },
-      });
+      },
+      ...Object.keys(existing.get(key)?.indexes ?? {}).map((indexName) => ({
+        Delete: {
+          TableName: tableName,
+          Key: toDynamoPrimaryKey(
+            keyConfig,
+            collectionPartitionKey(collection),
+            queryIndexItemSortKey(indexName, key),
+          ),
+        },
+      })),
+    ];
+
+    if (transactItems.length > 0 && transactItems.length + entryItems.length > 100) {
+      await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
+      transactItems = [];
     }
 
-    await client.send(
-      new TransactWriteCommand({
-        TransactItems: transactItems,
-      }),
-    );
+    transactItems.push(...entryItems);
+  }
+
+  if (transactItems.length > 0) {
+    await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
   }
 }
 
@@ -2374,6 +2866,11 @@ function isTransactionConditionalCheckFailed(error: unknown): boolean {
   );
 }
 
+function isMissingDynamoIndexError(error: unknown, indexName: string): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("does not have the specified index") && message.includes(indexName);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -2404,6 +2901,17 @@ function uniqueDynamoKeys(keys: DynamoPrimaryKey[]): DynamoPrimaryKey[] {
   }
 
   return unique;
+}
+
+function diffRemovedIndexNames(
+  previous: ResolvedIndexKeys | undefined,
+  next: ResolvedIndexKeys,
+): string[] {
+  if (!previous) {
+    return [];
+  }
+
+  return Object.keys(previous).filter((name) => next[name] === undefined);
 }
 
 function uniqueStrings(values: string[]): string[] {

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -33,6 +33,7 @@ import {
 
 const MAX_BATCH_WRITE = 25;
 const MAX_BATCH_GET = 100;
+const MAX_TRANSACT_WRITE = 100;
 const BATCH_RETRY_LIMIT = 10;
 const META_PARTITION_KEY = "META";
 const OUTDATED_PAGE_LIMIT = 100;
@@ -1496,6 +1497,8 @@ function buildDynamoQueryIndexCondition(
       expressionAttributeNames,
       expressionAttributeValues: {
         ":queryPk": queryPk,
+        // Prefix queries intentionally omit the value separator so values that share the same
+        // leading characters remain contiguous in the query index sort key.
         ":querySkPrefix": encodedFieldValue(beginsValue),
       },
     };
@@ -1840,6 +1843,10 @@ async function putDocumentAndMetadata(
     })),
   ];
 
+  assertTransactWriteItemCount(
+    transactItems,
+    `DynamoDB document write for "${docItem.collection}/${docItem.key}"`,
+  );
   await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
 }
 
@@ -1888,7 +1895,12 @@ async function putDocumentAndMetadataBatch(
       })),
     ];
 
-    if (transactItems.length > 0 && transactItems.length + entryItems.length > 100) {
+    assertTransactWriteItemCount(
+      entryItems,
+      `DynamoDB batch document write for "${entry.docItem.collection}/${entry.docItem.key}"`,
+    );
+
+    if (transactItems.length + entryItems.length > MAX_TRANSACT_WRITE) {
       await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
       transactItems = [];
     }
@@ -1909,42 +1921,44 @@ async function deleteDocumentAndMetadata(
   key: string,
   indexNames: readonly string[],
 ): Promise<void> {
-  await client.send(
-    new TransactWriteCommand({
-      TransactItems: [
-        {
-          Delete: {
-            TableName: tableName,
-            Key: toDynamoPrimaryKey(
-              keyConfig,
-              collectionPartitionKey(collection),
-              documentSortKey(key),
-            ),
-          },
-        },
-        {
-          Delete: {
-            TableName: tableName,
-            Key: toDynamoPrimaryKey(
-              keyConfig,
-              collectionPartitionKey(collection),
-              metadataSortKey(key),
-            ),
-          },
-        },
-        ...indexNames.map((indexName) => ({
-          Delete: {
-            TableName: tableName,
-            Key: toDynamoPrimaryKey(
-              keyConfig,
-              collectionPartitionKey(collection),
-              queryIndexItemSortKey(indexName, key),
-            ),
-          },
-        })),
-      ],
-    }),
+  const transactItems: TransactWriteItem[] = [
+    {
+      Delete: {
+        TableName: tableName,
+        Key: toDynamoPrimaryKey(
+          keyConfig,
+          collectionPartitionKey(collection),
+          documentSortKey(key),
+        ),
+      },
+    },
+    {
+      Delete: {
+        TableName: tableName,
+        Key: toDynamoPrimaryKey(
+          keyConfig,
+          collectionPartitionKey(collection),
+          metadataSortKey(key),
+        ),
+      },
+    },
+    ...indexNames.map((indexName) => ({
+      Delete: {
+        TableName: tableName,
+        Key: toDynamoPrimaryKey(
+          keyConfig,
+          collectionPartitionKey(collection),
+          queryIndexItemSortKey(indexName, key),
+        ),
+      },
+    })),
+  ];
+
+  assertTransactWriteItemCount(
+    transactItems,
+    `DynamoDB document delete for "${collection}/${key}"`,
   );
+  await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
 }
 
 async function deleteDocumentAndMetadataBatch(
@@ -1993,7 +2007,12 @@ async function deleteDocumentAndMetadataBatch(
       })),
     ];
 
-    if (transactItems.length > 0 && transactItems.length + entryItems.length > 100) {
+    assertTransactWriteItemCount(
+      entryItems,
+      `DynamoDB batch document delete for "${collection}/${key}"`,
+    );
+
+    if (transactItems.length + entryItems.length > MAX_TRANSACT_WRITE) {
       await client.send(new TransactWriteCommand({ TransactItems: transactItems }));
       transactItems = [];
     }
@@ -2868,7 +2887,28 @@ function isTransactionConditionalCheckFailed(error: unknown): boolean {
 
 function isMissingDynamoIndexError(error: unknown, indexName: string): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return message.includes("does not have the specified index") && message.includes(indexName);
+  const name =
+    isRecord(error) && typeof error.name === "string"
+      ? error.name
+      : isRecord(error) && typeof error.code === "string"
+        ? error.code
+        : error instanceof Error && "name" in error && typeof error.name === "string"
+          ? error.name
+          : "";
+  return name === "ValidationException" && message.includes(indexName);
+}
+
+function assertTransactWriteItemCount(
+  transactItems: readonly TransactWriteItem[],
+  operation: string,
+): void {
+  if (transactItems.length <= MAX_TRANSACT_WRITE) {
+    return;
+  }
+
+  throw new Error(
+    `${operation} exceeds DynamoDB's ${String(MAX_TRANSACT_WRITE)}-item transaction limit`,
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/integration/dynamodb-engine.test.ts
+++ b/tests/integration/dynamodb-engine.test.ts
@@ -6,7 +6,7 @@ import {
   waitUntilTableExists,
   waitUntilTableNotExists,
 } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 import {
   afterAll,
   beforeAll,
@@ -91,6 +91,34 @@ async function waitForDynamoDbReady(): Promise<void> {
   );
 }
 
+function encodeDynamoComparable(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+async function queryIndexRows(
+  collection: string,
+  indexName: string,
+  prefix: string,
+): Promise<unknown[]> {
+  const response = (await documentClient.send(
+    new QueryCommand({
+      TableName: tableName,
+      IndexName: "query_idx",
+      KeyConditionExpression: "#queryPk = :queryPk AND begins_with(#querySk, :querySkPrefix)",
+      ExpressionAttributeNames: {
+        "#queryPk": "queryPk",
+        "#querySk": "querySk",
+      },
+      ExpressionAttributeValues: {
+        ":queryPk": `QIDX#COL#${collection}#IDX#${encodeDynamoComparable(indexName)}`,
+        ":querySkPrefix": encodeDynamoComparable(prefix),
+      },
+    }),
+  )) as { Items?: unknown[] };
+
+  return response.Items ?? [];
+}
+
 async function createTableForTests(): Promise<void> {
   try {
     await baseClient.send(
@@ -99,6 +127,8 @@ async function createTableForTests(): Promise<void> {
         AttributeDefinitions: [
           { AttributeName: "pk", AttributeType: "S" },
           { AttributeName: "sk", AttributeType: "S" },
+          { AttributeName: "queryPk", AttributeType: "S" },
+          { AttributeName: "querySk", AttributeType: "S" },
           { AttributeName: "migrationOutdatedPk", AttributeType: "S" },
           { AttributeName: "migrationOutdatedSk", AttributeType: "S" },
           { AttributeName: "migrationSyncPk", AttributeType: "S" },
@@ -109,6 +139,16 @@ async function createTableForTests(): Promise<void> {
           { AttributeName: "sk", KeyType: "RANGE" },
         ],
         GlobalSecondaryIndexes: [
+          {
+            IndexName: "query_idx",
+            KeySchema: [
+              { AttributeName: "queryPk", KeyType: "HASH" },
+              { AttributeName: "querySk", KeyType: "RANGE" },
+            ],
+            Projection: {
+              ProjectionType: "ALL",
+            },
+          },
           {
             IndexName: "migration_outdated_idx",
             KeySchema: [
@@ -249,6 +289,24 @@ describe("dynamoDbEngine integration", () => {
       id: "u1",
       name: "Samuel",
     });
+  });
+
+  test("update rewrites query index rows when an indexed value changes", async () => {
+    await engine.create(
+      collection,
+      "u1",
+      { id: "u1", email: "old@example.com" },
+      { byEmail: "old@example.com" },
+    );
+    await engine.update(
+      collection,
+      "u1",
+      { id: "u1", email: "new@example.com" },
+      { byEmail: "new@example.com" },
+    );
+
+    expect(await queryIndexRows(collection, "byEmail", "old@example.com")).toHaveLength(0);
+    expect(await queryIndexRows(collection, "byEmail", "new@example.com")).toHaveLength(1);
   });
 
   test("update throws not-found error when key does not exist", async () => {

--- a/tests/unit/dynamodb-engine.test.ts
+++ b/tests/unit/dynamodb-engine.test.ts
@@ -1,6 +1,71 @@
+import {
+  BatchGetCommand,
+  GetCommand,
+  QueryCommand,
+  TransactWriteCommand,
+  UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { describe, expect, test } from "bun:test";
 
 import { dynamoDbEngine } from "../../src/engines/dynamodb";
+
+class FakeDynamoClient {
+  sequenceValue = 0;
+  sentCommands: string[] = [];
+
+  constructor(private readonly existingDocument: Record<string, unknown> | null = null) {}
+
+  async send(command: { input: unknown }): Promise<unknown> {
+    this.sentCommands.push(command.constructor.name);
+
+    if (command instanceof UpdateCommand) {
+      this.sequenceValue += 1;
+      return { Attributes: { value: this.sequenceValue } };
+    }
+
+    if (command instanceof GetCommand) {
+      return { Item: this.existingDocument };
+    }
+
+    if (command instanceof BatchGetCommand) {
+      return { Responses: { "test-table": this.existingDocument ? [this.existingDocument] : [] } };
+    }
+
+    if (command instanceof TransactWriteCommand) {
+      return {};
+    }
+
+    if (command instanceof QueryCommand) {
+      return { Items: [] };
+    }
+
+    throw new Error(`Unexpected command ${command.constructor.name}`);
+  }
+}
+
+function makeIndexes(count: number): Record<string, string> {
+  const indexes: Record<string, string> = {};
+
+  for (let index = 0; index < count; index += 1) {
+    indexes[`idx${String(index)}`] = `value-${String(index)}`;
+  }
+
+  return indexes;
+}
+
+function makeStoredDocument(indexes: Record<string, string>): Record<string, unknown> {
+  return {
+    pk: "COL#users",
+    sk: "DOC#u1",
+    itemType: "doc",
+    collection: "users",
+    key: "u1",
+    createdAt: 1,
+    writeVersion: 1,
+    doc: { id: "u1" },
+    indexes,
+  };
+}
 
 describe("dynamoDbEngine", () => {
   test('reports uniqueConstraints capability as "none"', () => {
@@ -14,5 +79,43 @@ describe("dynamoDbEngine", () => {
     });
 
     expect(engine.capabilities?.uniqueConstraints).toBe("none");
+  });
+
+  test("create fails fast when a single DynamoDB transaction would exceed 100 items", async () => {
+    const client = new FakeDynamoClient();
+    const engine = dynamoDbEngine({
+      client,
+      tableName: "test-table",
+    });
+
+    await expect(engine.create("users", "u1", { id: "u1" }, makeIndexes(99))).rejects.toThrow(
+      /100-item transaction limit/i,
+    );
+    expect(client.sentCommands).toEqual(["UpdateCommand"]);
+  });
+
+  test("delete fails fast when a single DynamoDB transaction would exceed 100 items", async () => {
+    const indexes = makeIndexes(99);
+    const client = new FakeDynamoClient(makeStoredDocument(indexes));
+    const engine = dynamoDbEngine({
+      client,
+      tableName: "test-table",
+    });
+
+    await expect(engine.delete("users", "u1")).rejects.toThrow(/100-item transaction limit/i);
+    expect(client.sentCommands).toEqual(["GetCommand"]);
+  });
+
+  test("batchSet fails fast when one document would exceed 100 transaction items", async () => {
+    const client = new FakeDynamoClient();
+    const engine = dynamoDbEngine({
+      client,
+      tableName: "test-table",
+    });
+
+    await expect(
+      engine.batchSet("users", [{ key: "u1", doc: { id: "u1" }, indexes: makeIndexes(99) }]),
+    ).rejects.toThrow(/100-item transaction limit/i);
+    expect(client.sentCommands).toEqual(["BatchGetCommand", "UpdateCommand"]);
   });
 });

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -379,6 +379,12 @@ class FakeDynamoClient {
       return {};
     }
 
+    if (typeof response.name === "string" && typeof response.message === "string") {
+      const error = new Error(response.message) as Error & { name: string };
+      error.name = response.name;
+      throw error;
+    }
+
     return response;
   }
 }
@@ -399,6 +405,30 @@ function makeDynamoDocItem(
     writeVersion: 1,
     doc,
     indexes,
+  };
+}
+
+function encodeDynamoComparable(value: string): string {
+  return Buffer.from(value, "utf8").toString("hex");
+}
+
+function makeDynamoQueryIndexItem(
+  key: string,
+  createdAt: number,
+  indexName: string,
+  indexValue: string,
+) {
+  return {
+    pk: "COL#users",
+    sk: `QIDX#${encodeDynamoComparable(indexName)}#${encodeDynamoComparable(key)}`,
+    itemType: "query_index",
+    collection: "users",
+    key,
+    indexName,
+    indexValue,
+    createdAt,
+    queryPk: `QIDX#COL#users#IDX#${encodeDynamoComparable(indexName)}`,
+    querySk: `${encodeDynamoComparable(indexValue)}#${String(createdAt).padStart(16, "0")}#${encodeDynamoComparable(key)}`,
   };
 }
 
@@ -968,8 +998,50 @@ describe("non-SQL query pushdown", () => {
     expect(db.documentGetCalls).toBe(0);
   });
 
-  test("dynamodb query adds a filter expression for index filters", async () => {
+  test("dynamodb query uses a secondary lookup item query instead of FilterExpression scans", async () => {
     const client = new FakeDynamoClient([
+      {
+        Items: [makeDynamoQueryIndexItem("u2", 1, "byEmail", "alex@example.com")],
+      },
+      {
+        Responses: {
+          tbl: [makeDynamoDocItem("u2", 1, { byEmail: "alex@example.com" }, { id: "u2" })],
+        },
+      },
+    ]);
+    const engine = dynamoDbEngine({
+      client,
+      tableName: "tbl",
+    });
+
+    const result = await engine.query("users", {
+      index: "byEmail",
+      filter: { value: { $begins: "a" } },
+    });
+
+    expect(client.inputs).toHaveLength(2);
+    expect(client.inputs[0]).toMatchObject({
+      IndexName: "query_idx",
+      KeyConditionExpression: "#queryPk = :queryPk AND begins_with(#querySk, :querySkPrefix)",
+      ExpressionAttributeNames: {
+        "#queryPk": "queryPk",
+        "#querySk": "querySk",
+      },
+      ExpressionAttributeValues: {
+        ":queryPk": `QIDX#COL#users#IDX#${encodeDynamoComparable("byEmail")}`,
+        ":querySkPrefix": encodeDynamoComparable("a"),
+      },
+    });
+    expect(client.inputs[0]).not.toHaveProperty("FilterExpression");
+    expect(result.documents.map((doc) => doc.key)).toEqual(["u2"]);
+  });
+
+  test("dynamodb query falls back to collection filtering when the secondary lookup index is unavailable", async () => {
+    const client = new FakeDynamoClient([
+      {
+        name: "ValidationException",
+        message: "The table does not have the specified index: query_idx",
+      },
       {
         Items: [
           makeDynamoDocItem("u1", 2, { byEmail: "sam@example.com" }, { id: "u1" }),
@@ -987,8 +1059,8 @@ describe("non-SQL query pushdown", () => {
       filter: { value: { $begins: "a" } },
     });
 
-    expect(client.inputs).toHaveLength(1);
-    expect(client.inputs[0]).toMatchObject({
+    expect(client.inputs).toHaveLength(2);
+    expect(client.inputs[1]).toMatchObject({
       FilterExpression: "begins_with(#indexes.#indexName, :f_begins)",
       ExpressionAttributeNames: {
         "#indexes": "indexes",


### PR DESCRIPTION
## Summary
Fixes #117 by replacing DynamoDB partition-wide `FilterExpression` scans with query-index lookups when an indexed filter can be pushed down.

## Root cause
`listDocumentsByQuery()` still queried the collection partition and filtered on stored index values after the read. That meant callers could provide an index and still incur partition-wide reads, with latency and read amplification growing with collection size.

## What changed
- add persisted DynamoDB query-index rows plus a configurable `queryIndexName` defaulting to `query_idx`
- route supported equality, prefix, and range-style index filters through the query index before batch-loading matched documents
- preserve the existing collection-filter fallback when the lookup index is unavailable or the filter shape is not pushdown-safe
- keep query-index rows in sync on create, put, update, delete, batchSet, and batchDelete operations
- add unit coverage for query-index pushdown and fallback behavior
- add integration coverage that verifies indexed value updates rewrite query-index rows
- include a patch changeset for release publication

## Impact
DynamoDB-backed indexed queries now use an index-first lookup path for common supported predicates instead of behaving like partition scans behind the API.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun run test`
- `bun run services:up:dynamodb && bun run test:integration:dynamodb`

## Validation notes
The unit suite, formatting, lint-fix, and typecheck passed locally. DynamoDB integration validation could not run in this environment because Docker was unavailable (`Cannot connect to the Docker daemon at unix:///Users/samuellaycock/.orbstack/run/docker.sock`).