### PR TITLE
[codex] Fix Redis query pushdown and batch reads

### DIFF
--- a/.changeset/redis-query-batching.md
+++ b/.changeset/redis-query-batching.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Push Redis indexed queries down into Redis lex-sorted index sets and batch
+document reads through a single script call, while preserving scan fallback for
+query shapes that cannot be pushed down safely.

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -1,6 +1,10 @@
 import { DefaultMigrator } from "../migrator";
 import { getPreparedSerializedDocument, prepareDocumentForStorage } from "./document-preparation";
-import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
+import {
+  encodeQueryPageCursor,
+  resolveQueryPageCursorPosition,
+  resolveQueryPageStartIndex,
+} from "./query-cursor";
 import {
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
@@ -22,6 +26,8 @@ import {
 const DEFAULT_KEY_PREFIX = "nosql_odm";
 const OUTDATED_PAGE_LIMIT = 100;
 const OUTDATED_SYNC_CHUNK_SIZE = 100;
+const INDEX_MEMBER_CREATED_AT_WIDTH = 20;
+const INDEX_QUERY_CHUNK_SIZE = 64;
 const NULL_INDEX_SIGNATURE = "";
 const NULL_INDEX_SIGNATURE_TOKEN = "__null__";
 
@@ -40,6 +46,14 @@ end
 
 local function uniqueOwnerKey(prefix, collection, indexName, indexValue)
   return prefix .. ":unique:" .. collection .. ":" .. cjson.encode({indexName, indexValue})
+end
+
+local function indexSetKey(prefix, collection, indexName)
+  return prefix .. ":index:" .. collection .. ":" .. indexName
+end
+
+local function encodeIndexMember(indexValue, createdAt, key)
+  return tostring(indexValue) .. "\\0" .. string.format("%020d", tonumber(createdAt)) .. "\\0" .. key
 end
 
 local function decodeIndexRecord(raw)
@@ -63,6 +77,18 @@ local function releaseUniqueIndexes(prefix, collection, key, uniqueIndexes)
     if currentOwner == key then
       redis.call("DEL", ownerKey)
     end
+  end
+end
+
+local function removeIndexEntries(prefix, collection, key, indexes, createdAt)
+  for indexName, indexValue in pairs(indexes) do
+    redis.call("ZREM", indexSetKey(prefix, collection, indexName), encodeIndexMember(indexValue, createdAt, key))
+  end
+end
+
+local function assignIndexEntries(prefix, collection, key, indexes, createdAt)
+  for indexName, indexValue in pairs(indexes) do
+    redis.call("ZADD", indexSetKey(prefix, collection, indexName), 0, encodeIndexMember(indexValue, createdAt, key))
   end
 end
 
@@ -176,8 +202,12 @@ if not createdAt then
 end
 
 removePreviousIndexes(prefix, collection, key, KEYS[3])
+if exists then
+  removeIndexEntries(prefix, collection, key, decodeIndexRecord(redis.call("HGET", KEYS[1], "indexes")), createdAt)
+end
 releaseUniqueIndexes(prefix, collection, key, previousUniqueIndexes)
 assignUniqueIndexes(prefix, collection, key, nextUniqueIndexes)
+assignIndexEntries(prefix, collection, key, decodeIndexRecord(indexesJson), createdAt)
 
 local nextWriteVersion = 1
 if exists then
@@ -228,6 +258,14 @@ local function uniqueOwnerKey(prefix, collection, indexName, indexValue)
   return prefix .. ":unique:" .. collection .. ":" .. cjson.encode({indexName, indexValue})
 end
 
+local function indexSetKey(prefix, collection, indexName)
+  return prefix .. ":index:" .. collection .. ":" .. indexName
+end
+
+local function encodeIndexMember(indexValue, createdAt, key)
+  return tostring(indexValue) .. "\\0" .. string.format("%020d", tonumber(createdAt)) .. "\\0" .. key
+end
+
 local function decodeIndexRecord(raw)
   if raw == false or raw == nil or raw == "" then
     return {}
@@ -255,6 +293,8 @@ end
 local prefix = ARGV[1]
 local collection = ARGV[2]
 local key = ARGV[3]
+local createdAt = redis.call("HGET", KEYS[1], "createdAt")
+local indexes = decodeIndexRecord(redis.call("HGET", KEYS[1], "indexes"))
 
 local oldTarget = redis.call("HGET", KEYS[1], "migrationTargetVersion")
 local oldState = redis.call("HGET", KEYS[1], "migrationVersionState")
@@ -270,6 +310,12 @@ releaseUniqueIndexes(
   key,
   decodeIndexRecord(redis.call("HGET", KEYS[1], "uniqueIndexes"))
 )
+
+if createdAt then
+  for indexName, indexValue in pairs(indexes) do
+    redis.call("ZREM", indexSetKey(prefix, collection, indexName), encodeIndexMember(indexValue, createdAt, key))
+  end
+end
 
 redis.call("DEL", KEYS[1])
 redis.call("ZREM", KEYS[2], key)
@@ -371,6 +417,51 @@ return redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], ARGV[2], "LIMIT", 0, tonumb
 
 const FETCH_ZSET_PAGE_BY_SCORE_SCRIPT = `
 return redis.call("ZRANGEBYSCORE", KEYS[1], ARGV[1], "+inf", "WITHSCORES", "LIMIT", 0, tonumber(ARGV[2]))
+`;
+
+const FETCH_BATCH_DOCUMENTS_SCRIPT = `
+local function documentHashKey(prefix, collection, key)
+  return prefix .. ":doc:" .. collection .. ":" .. key
+end
+
+local results = {}
+
+for _, key in ipairs(ARGV) do
+  local values = redis.call(
+    "HMGET",
+    documentHashKey(KEYS[1], KEYS[2], key),
+    "createdAt",
+    "writeVersion",
+    "doc",
+    "indexes",
+    "migrationTargetVersion",
+    "migrationVersionState",
+    "migrationIndexSignature"
+  )
+
+  if values[1] ~= false and values[3] ~= false and values[4] ~= false then
+    table.insert(results, cjson.encode({
+      key = key,
+      createdAt = values[1],
+      writeVersion = values[2],
+      doc = values[3],
+      indexes = values[4],
+      migrationTargetVersion = values[5],
+      migrationVersionState = values[6],
+      migrationIndexSignature = values[7]
+    }))
+  end
+end
+
+return results
+`;
+
+const FETCH_INDEX_PAGE_SCRIPT = `
+if ARGV[1] == "desc" then
+  return redis.call("ZREVRANGEBYLEX", KEYS[1], ARGV[2], ARGV[3], "LIMIT", 0, tonumber(ARGV[4]))
+end
+
+return redis.call("ZRANGEBYLEX", KEYS[1], ARGV[2], ARGV[3], "LIMIT", 0, tonumber(ARGV[4]))
 `;
 
 const BUILD_MISMATCH_SET_SCRIPT = `
@@ -634,32 +725,37 @@ export function redisEngine(options: RedisEngineOptions): RedisQueryEngine {
     },
 
     async query(collection, params) {
-      const records = await listCollectionDocuments(client, keyPrefix, collection);
-      const matched = matchDocuments(records, params);
+      const range = params.index && params.filter ? buildIndexLexRange(params.filter.value) : null;
+
+      if (params.index && params.filter && params.sort && range) {
+        return querySortedIndex(client, keyPrefix, collection, params, range, false);
+      }
+
+      const matched = await findMatchingDocuments(client, keyPrefix, collection, params);
 
       return paginate(collection, matched, params);
     },
 
     async queryWithMetadata(collection, params) {
-      const records = await listCollectionDocuments(client, keyPrefix, collection);
-      const matched = matchDocuments(records, params);
+      const range = params.index && params.filter ? buildIndexLexRange(params.filter.value) : null;
+
+      if (params.index && params.filter && params.sort && range) {
+        return querySortedIndex(client, keyPrefix, collection, params, range, true);
+      }
+
+      const matched = await findMatchingDocuments(client, keyPrefix, collection, params);
 
       return paginateWithWriteTokens(collection, matched, params);
     },
 
     async batchGet(collection, keys) {
-      const fetched = new Map<string, StoredDocumentRecord>();
+      const fetched = await loadDocumentRecordMap(
+        client,
+        keyPrefix,
+        collection,
+        uniqueStrings(keys),
+      );
       const results: KeyedDocument[] = [];
-
-      for (const key of uniqueStrings(keys)) {
-        const record = await loadDocumentRecord(client, keyPrefix, collection, key);
-
-        if (!record) {
-          continue;
-        }
-
-        fetched.set(key, record);
-      }
 
       for (const key of keys) {
         const record = fetched.get(key);
@@ -678,18 +774,13 @@ export function redisEngine(options: RedisEngineOptions): RedisQueryEngine {
     },
 
     async batchGetWithMetadata(collection, keys) {
-      const fetched = new Map<string, StoredDocumentRecord>();
+      const fetched = await loadDocumentRecordMap(
+        client,
+        keyPrefix,
+        collection,
+        uniqueStrings(keys),
+      );
       const results: KeyedDocument[] = [];
-
-      for (const key of uniqueStrings(keys)) {
-        const record = await loadDocumentRecord(client, keyPrefix, collection, key);
-
-        if (!record) {
-          continue;
-        }
-
-        fetched.set(key, record);
-      }
 
       for (const key of keys) {
         const record = fetched.get(key);
@@ -1059,6 +1150,283 @@ async function loadDocumentRecord(
   }
 
   return parseStoredDocumentRecord(key, fields);
+}
+
+async function loadDocumentRecordMap(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  keys: string[],
+): Promise<Map<string, StoredDocumentRecord>> {
+  if (keys.length === 0) {
+    return new Map();
+  }
+
+  const raw = await evalScript(client, FETCH_BATCH_DOCUMENTS_SCRIPT, [keyPrefix, collection], keys);
+  const entries = parseBatchDocumentEntries(raw);
+  const records = new Map<string, StoredDocumentRecord>();
+
+  for (const entry of entries) {
+    records.set(
+      entry.key,
+      parseStoredDocumentRecord(entry.key, {
+        createdAt: entry.createdAt,
+        writeVersion: entry.writeVersion,
+        doc: entry.doc,
+        indexes: entry.indexes,
+        ...(entry.migrationTargetVersion === undefined
+          ? {}
+          : { migrationTargetVersion: entry.migrationTargetVersion }),
+        ...(entry.migrationVersionState === undefined
+          ? {}
+          : { migrationVersionState: entry.migrationVersionState }),
+        ...(entry.migrationIndexSignature === undefined
+          ? {}
+          : { migrationIndexSignature: entry.migrationIndexSignature }),
+      }),
+    );
+  }
+
+  return records;
+}
+
+async function findMatchingDocuments(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  params: QueryParams,
+): Promise<StoredDocumentRecord[]> {
+  if (!params.index || !params.filter) {
+    const records = await listCollectionDocuments(client, keyPrefix, collection);
+    return matchDocuments(records, params);
+  }
+
+  const range = buildIndexLexRange(params.filter.value);
+
+  if (!range) {
+    const records = await listCollectionDocuments(client, keyPrefix, collection);
+    return matchDocuments(records, params);
+  }
+
+  return listIndexedDocuments(client, keyPrefix, collection, params, range);
+}
+
+async function listIndexedDocuments(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  params: QueryParams,
+  range: IndexLexRange,
+): Promise<StoredDocumentRecord[]> {
+  const indexName = params.index!;
+  const members = await fetchAllIndexMembers(
+    client,
+    keyPrefix,
+    collection,
+    indexName,
+    range,
+    "asc",
+  );
+  const recordsByKey = await loadDocumentRecordMap(
+    client,
+    keyPrefix,
+    collection,
+    uniqueStrings(members.map((member) => decodeIndexMember(member).key)),
+  );
+  const matched: StoredDocumentRecord[] = [];
+
+  for (const member of members) {
+    const parsed = decodeIndexMember(member);
+    const record = recordsByKey.get(parsed.key);
+
+    if (!record) {
+      await removeDanglingIndexMember(client, keyPrefix, collection, indexName, member);
+      continue;
+    }
+
+    const currentIndexValue = record.indexes[indexName];
+    if (
+      currentIndexValue !== parsed.indexValue ||
+      !matchesFilter(currentIndexValue, params.filter!.value)
+    ) {
+      await removeDanglingIndexMember(client, keyPrefix, collection, indexName, member);
+      continue;
+    }
+
+    matched.push(record);
+  }
+
+  matched.sort((a, b) => {
+    if (a.createdAt !== b.createdAt) {
+      return a.createdAt - b.createdAt;
+    }
+
+    return a.key.localeCompare(b.key);
+  });
+
+  return matched;
+}
+
+async function querySortedIndex(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  params: QueryParams,
+  range: IndexLexRange,
+  includeWriteTokens: boolean,
+): Promise<EngineQueryResult> {
+  const indexName = params.index!;
+  const limit = normalizeLimit(params.limit);
+
+  if (limit === 0) {
+    resolveQueryPageCursorPosition(collection, params);
+    return {
+      documents: [],
+      cursor: null,
+    };
+  }
+
+  if (limit === null) {
+    const members = await fetchAllIndexMembers(
+      client,
+      keyPrefix,
+      collection,
+      indexName,
+      range,
+      params.sort!,
+    );
+    const records = await loadRecordsFromIndexMembers(
+      client,
+      keyPrefix,
+      collection,
+      indexName,
+      params,
+      members,
+    );
+
+    return {
+      documents: records.map((record) => ({
+        key: record.key,
+        doc: structuredClone(record.doc),
+        ...(includeWriteTokens ? { writeToken: String(record.writeVersion) } : {}),
+      })),
+      cursor: null,
+    };
+  }
+
+  const cursorPosition = resolveQueryPageCursorPosition(collection, params);
+  const collected: StoredDocumentRecord[] = [];
+  let cursorMember =
+    cursorPosition?.kind === "sorted-index"
+      ? encodeIndexMember(
+          cursorPosition.indexValue,
+          cursorPosition.createdAt ?? 0,
+          cursorPosition.key,
+        )
+      : null;
+
+  while (collected.length < limit + 1) {
+    const requestSize = Math.max(limit + 1 - collected.length, INDEX_QUERY_CHUNK_SIZE);
+    const batch = await fetchIndexMembersPage(
+      client,
+      keyPrefix,
+      collection,
+      indexName,
+      range,
+      params.sort!,
+      cursorMember,
+      requestSize,
+    );
+
+    if (batch.length === 0) {
+      break;
+    }
+
+    const valid = await loadRecordsFromIndexMembers(
+      client,
+      keyPrefix,
+      collection,
+      indexName,
+      params,
+      batch,
+    );
+
+    for (const record of valid) {
+      collected.push(record);
+
+      if (collected.length >= limit + 1) {
+        break;
+      }
+    }
+
+    cursorMember = batch[batch.length - 1] ?? null;
+
+    if (batch.length < requestSize) {
+      break;
+    }
+  }
+
+  const page = collected.slice(0, limit);
+  const hasMore = collected.length > limit;
+
+  return {
+    documents: page.map((record) => ({
+      key: record.key,
+      doc: structuredClone(record.doc),
+      ...(includeWriteTokens ? { writeToken: String(record.writeVersion) } : {}),
+    })),
+    cursor:
+      hasMore && page.length > 0
+        ? encodeQueryPageCursor(collection, params, {
+            key: page[page.length - 1]!.key,
+            createdAt: page[page.length - 1]!.createdAt,
+            indexValue: page[page.length - 1]!.indexes[indexName] ?? "",
+          })
+        : null,
+  };
+}
+
+async function loadRecordsFromIndexMembers(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  indexName: string,
+  params: QueryParams,
+  members: string[],
+): Promise<StoredDocumentRecord[]> {
+  const decoded = members.map((member) => ({
+    member,
+    parsed: decodeIndexMember(member),
+  }));
+  const recordsByKey = await loadDocumentRecordMap(
+    client,
+    keyPrefix,
+    collection,
+    uniqueStrings(decoded.map(({ parsed }) => parsed.key)),
+  );
+  const records: StoredDocumentRecord[] = [];
+
+  for (const { member, parsed } of decoded) {
+    const record = recordsByKey.get(parsed.key);
+
+    if (!record) {
+      await removeDanglingIndexMember(client, keyPrefix, collection, indexName, member);
+      continue;
+    }
+
+    const currentIndexValue = record.indexes[indexName];
+    if (
+      currentIndexValue !== parsed.indexValue ||
+      !matchesFilter(currentIndexValue, params.filter!.value)
+    ) {
+      await removeDanglingIndexMember(client, keyPrefix, collection, indexName, member);
+      continue;
+    }
+
+    records.push(record);
+  }
+
+  return records;
 }
 
 async function syncMigrationMetadataForCriteria(
@@ -1734,6 +2102,257 @@ function parseUpsertResult(
   throw new Error("Redis returned an invalid upsert result");
 }
 
+interface IndexLexRange {
+  min: string;
+  max: string;
+}
+
+interface DecodedIndexMember {
+  indexValue: string;
+  createdAt: number;
+  key: string;
+}
+
+interface BatchDocumentEntry {
+  key: string;
+  createdAt: string;
+  writeVersion: string;
+  doc: string;
+  indexes: string;
+  migrationTargetVersion?: string;
+  migrationVersionState?: string;
+  migrationIndexSignature?: string;
+}
+
+function buildIndexLexRange(filter: string | number | FieldCondition): IndexLexRange | null {
+  if (typeof filter === "string" || typeof filter === "number") {
+    return buildEqualityLexRange(String(filter));
+  }
+
+  if (filter.$eq !== undefined) {
+    const value = normalizeIndexRangeValue(filter.$eq);
+    return value === null ? null : buildEqualityLexRange(value);
+  }
+
+  if (
+    filter.$begins !== undefined &&
+    filter.$gt === undefined &&
+    filter.$gte === undefined &&
+    filter.$lt === undefined &&
+    filter.$lte === undefined &&
+    filter.$between === undefined
+  ) {
+    return {
+      min: `[${filter.$begins}`,
+      max: `[${filter.$begins}\xff`,
+    };
+  }
+
+  if (filter.$between !== undefined) {
+    const low = normalizeIndexRangeValue(filter.$between[0]);
+    const high = normalizeIndexRangeValue(filter.$between[1]);
+
+    if (low === null || high === null) {
+      return null;
+    }
+
+    return {
+      min: `[${low}\0`,
+      max: `[${high}\0\xff`,
+    };
+  }
+
+  if (
+    filter.$gt === undefined &&
+    filter.$gte === undefined &&
+    filter.$lt === undefined &&
+    filter.$lte === undefined
+  ) {
+    return null;
+  }
+
+  const gt = normalizeIndexRangeValue(filter.$gt);
+  const gte = normalizeIndexRangeValue(filter.$gte);
+  const lt = normalizeIndexRangeValue(filter.$lt);
+  const lte = normalizeIndexRangeValue(filter.$lte);
+
+  if (
+    (filter.$gt !== undefined && gt === null) ||
+    (filter.$gte !== undefined && gte === null) ||
+    (filter.$lt !== undefined && lt === null) ||
+    (filter.$lte !== undefined && lte === null)
+  ) {
+    return null;
+  }
+
+  return {
+    min: gt !== null ? `(${gt}\0\xff` : gte !== null ? `[${gte}\0` : "-",
+    max: lt !== null ? `(${lt}\0` : lte !== null ? `[${lte}\0\xff` : "+",
+  };
+}
+
+function buildEqualityLexRange(value: string): IndexLexRange {
+  return {
+    min: `[${value}\0`,
+    max: `[${value}\0\xff`,
+  };
+}
+
+function normalizeIndexRangeValue(value: unknown): string | null {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+
+  return null;
+}
+
+async function fetchAllIndexMembers(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  indexName: string,
+  range: IndexLexRange,
+  sort: "asc" | "desc",
+): Promise<string[]> {
+  const members: string[] = [];
+  let cursorMember: string | null = null;
+
+  while (true) {
+    const batch = await fetchIndexMembersPage(
+      client,
+      keyPrefix,
+      collection,
+      indexName,
+      range,
+      sort,
+      cursorMember,
+      INDEX_QUERY_CHUNK_SIZE,
+    );
+
+    if (batch.length === 0) {
+      return members;
+    }
+
+    members.push(...batch);
+    cursorMember = batch[batch.length - 1] ?? null;
+
+    if (batch.length < INDEX_QUERY_CHUNK_SIZE) {
+      return members;
+    }
+  }
+}
+
+async function fetchIndexMembersPage(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  indexName: string,
+  range: IndexLexRange,
+  sort: "asc" | "desc",
+  cursorMember: string | null,
+  count: number,
+): Promise<string[]> {
+  const raw = await evalScript(
+    client,
+    FETCH_INDEX_PAGE_SCRIPT,
+    [indexSetKey(keyPrefix, collection, indexName)],
+    [
+      sort,
+      sort === "desc"
+        ? cursorMember
+          ? `(${cursorMember}`
+          : range.max
+        : cursorMember
+          ? `(${cursorMember}`
+          : range.min,
+      sort === "desc" ? range.min : range.max,
+      String(count),
+    ],
+  );
+
+  return parseStringArray(raw, "indexed query member list");
+}
+
+async function removeDanglingIndexMember(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+  indexName: string,
+  member: string,
+): Promise<void> {
+  await client.zRem(indexSetKey(keyPrefix, collection, indexName), member);
+}
+
+function encodeIndexMember(indexValue: string, createdAt: number, key: string): string {
+  return `${indexValue}\0${String(createdAt).padStart(INDEX_MEMBER_CREATED_AT_WIDTH, "0")}\0${key}`;
+}
+
+function decodeIndexMember(member: string): DecodedIndexMember {
+  const firstSeparator = member.indexOf("\0");
+  const secondSeparator = firstSeparator === -1 ? -1 : member.indexOf("\0", firstSeparator + 1);
+
+  if (firstSeparator === -1 || secondSeparator === -1) {
+    throw new Error("Redis returned an invalid indexed query member");
+  }
+
+  return {
+    indexValue: member.slice(0, firstSeparator),
+    createdAt: parseInteger(
+      member.slice(firstSeparator + 1, secondSeparator),
+      "Redis returned an invalid indexed query member",
+    ),
+    key: member.slice(secondSeparator + 1),
+  };
+}
+
+function parseBatchDocumentEntries(value: unknown): BatchDocumentEntry[] {
+  const rawEntries = parseStringArray(value, "batch document list");
+  const entries: BatchDocumentEntry[] = [];
+
+  for (const entry of rawEntries) {
+    let parsed: unknown;
+
+    try {
+      parsed = JSON.parse(entry);
+    } catch {
+      throw new Error("Redis returned an invalid batch document list");
+    }
+
+    if (!isRecord(parsed)) {
+      throw new Error("Redis returned an invalid batch document list");
+    }
+
+    if (
+      typeof parsed.key !== "string" ||
+      typeof parsed.createdAt !== "string" ||
+      typeof parsed.writeVersion !== "string" ||
+      typeof parsed.doc !== "string" ||
+      typeof parsed.indexes !== "string"
+    ) {
+      throw new Error("Redis returned an invalid batch document list");
+    }
+
+    entries.push({
+      key: parsed.key,
+      createdAt: parsed.createdAt,
+      writeVersion: parsed.writeVersion,
+      doc: parsed.doc,
+      indexes: parsed.indexes,
+      ...(typeof parsed.migrationTargetVersion === "string"
+        ? { migrationTargetVersion: parsed.migrationTargetVersion }
+        : {}),
+      ...(typeof parsed.migrationVersionState === "string"
+        ? { migrationVersionState: parsed.migrationVersionState }
+        : {}),
+      ...(typeof parsed.migrationIndexSignature === "string"
+        ? { migrationIndexSignature: parsed.migrationIndexSignature }
+        : {}),
+    });
+  }
+
+  return entries;
+}
+
 function matchDocuments(
   records: StoredDocumentRecord[],
   params: QueryParams,
@@ -2177,6 +2796,10 @@ function collectionOrderKey(prefix: string, collection: string): string {
 
 function collectionSequenceKey(prefix: string, collection: string): string {
   return `${prefix}:sequence:${collection}`;
+}
+
+function indexSetKey(prefix: string, collection: string, indexName: string): string {
+  return `${prefix}:index:${collection}:${indexName}`;
 }
 
 function migrationTargetVersionSetKey(prefix: string, collection: string): string {

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -1326,7 +1326,7 @@ async function querySortedIndex(
     );
 
     return {
-      documents: records.map((record) => ({
+      documents: records.map(({ record }) => ({
         key: record.key,
         doc: structuredClone(record.doc),
         ...(includeWriteTokens ? { writeToken: String(record.writeVersion) } : {}),
@@ -1336,7 +1336,7 @@ async function querySortedIndex(
   }
 
   const cursorPosition = resolveQueryPageCursorPosition(collection, params);
-  const collected: StoredDocumentRecord[] = [];
+  const collected: IndexedRecordMatch[] = [];
   let cursorMember =
     cursorPosition?.kind === "sorted-index"
       ? encodeIndexMember(
@@ -1372,15 +1372,18 @@ async function querySortedIndex(
       batch,
     );
 
-    for (const record of valid) {
-      collected.push(record);
+    let lastCollectedMember: string | null = null;
+
+    for (const match of valid) {
+      collected.push(match);
+      lastCollectedMember = match.member;
 
       if (collected.length >= limit + 1) {
         break;
       }
     }
 
-    cursorMember = batch[batch.length - 1] ?? null;
+    cursorMember = lastCollectedMember ?? batch[batch.length - 1] ?? null;
 
     if (batch.length < requestSize) {
       break;
@@ -1391,7 +1394,7 @@ async function querySortedIndex(
   const hasMore = collected.length > limit;
 
   return {
-    documents: page.map((record) => ({
+    documents: page.map(({ record }) => ({
       key: record.key,
       doc: structuredClone(record.doc),
       ...(includeWriteTokens ? { writeToken: String(record.writeVersion) } : {}),
@@ -1399,9 +1402,9 @@ async function querySortedIndex(
     cursor:
       hasMore && page.length > 0
         ? encodeQueryPageCursor(collection, params, {
-            key: page[page.length - 1]!.key,
-            createdAt: page[page.length - 1]!.createdAt,
-            indexValue: page[page.length - 1]!.indexes[indexName] ?? "",
+            key: page[page.length - 1]!.record.key,
+            createdAt: page[page.length - 1]!.record.createdAt,
+            indexValue: page[page.length - 1]!.record.indexes[indexName] ?? "",
           })
         : null,
   };
@@ -1414,7 +1417,7 @@ async function loadRecordsFromIndexMembers(
   indexName: string,
   params: QueryParams,
   members: string[],
-): Promise<StoredDocumentRecord[]> {
+): Promise<IndexedRecordMatch[]> {
   const decoded = members.map((member) => ({
     member,
     parsed: decodeIndexMember(member),
@@ -1425,7 +1428,7 @@ async function loadRecordsFromIndexMembers(
     collection,
     uniqueStrings(decoded.map(({ parsed }) => parsed.key)),
   );
-  const records: StoredDocumentRecord[] = [];
+  const records: IndexedRecordMatch[] = [];
 
   for (const { member, parsed } of decoded) {
     const record = recordsByKey.get(parsed.key);
@@ -1444,7 +1447,10 @@ async function loadRecordsFromIndexMembers(
       continue;
     }
 
-    records.push(record);
+    records.push({
+      member,
+      record,
+    });
   }
 
   return records;
@@ -2173,6 +2179,11 @@ interface BatchDocumentEntry {
   migrationTargetVersion?: string;
   migrationVersionState?: string;
   migrationIndexSignature?: string;
+}
+
+interface IndexedRecordMatch {
+  member: string;
+  record: StoredDocumentRecord;
 }
 
 function buildIndexLexRange(filter: string | number | FieldCondition): IndexLexRange | null {

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -439,7 +439,7 @@ for _, key in ipairs(ARGV) do
     "migrationIndexSignature"
   )
 
-  if values[1] ~= false and values[3] ~= false and values[4] ~= false then
+  if values[1] ~= false and values[2] ~= false and values[3] ~= false and values[4] ~= false then
     table.insert(results, cjson.encode({
       key = key,
       createdAt = values[1],
@@ -462,6 +462,23 @@ if ARGV[1] == "desc" then
 end
 
 return redis.call("ZRANGEBYLEX", KEYS[1], ARGV[2], ARGV[3], "LIMIT", 0, tonumber(ARGV[4]))
+`;
+
+const ADD_INDEX_ENTRIES_SCRIPT = `
+for i = 1, #ARGV, 3 do
+  redis.call("ZADD", KEYS[1], 0, ARGV[i] .. "\\0" .. string.format("%020d", tonumber(ARGV[i + 1])) .. "\\0" .. ARGV[i + 2])
+end
+
+return 1
+`;
+
+const SET_STRING_IF_MISSING_SCRIPT = `
+if redis.call("EXISTS", KEYS[1]) == 0 then
+  redis.call("SET", KEYS[1], ARGV[1])
+  return 1
+end
+
+return 0
 `;
 
 const BUILD_MISMATCH_SET_SCRIPT = `
@@ -1201,6 +1218,8 @@ async function findMatchingDocuments(
     return matchDocuments(records, params);
   }
 
+  await ensureCollectionIndexesSynced(client, keyPrefix, collection);
+
   const range = buildIndexLexRange(params.filter.value);
 
   if (!range) {
@@ -1277,6 +1296,8 @@ async function querySortedIndex(
 ): Promise<EngineQueryResult> {
   const indexName = params.index!;
   const limit = normalizeLimit(params.limit);
+
+  await ensureCollectionIndexesSynced(client, keyPrefix, collection);
 
   if (limit === 0) {
     resolveQueryPageCursorPosition(collection, params);
@@ -1427,6 +1448,36 @@ async function loadRecordsFromIndexMembers(
   }
 
   return records;
+}
+
+async function ensureCollectionIndexesSynced(
+  client: RedisClientLike,
+  keyPrefix: string,
+  collection: string,
+): Promise<void> {
+  const markerKey = collectionIndexSyncKey(keyPrefix, collection);
+  const synced = await client.get(markerKey);
+
+  if (synced === "1") {
+    return;
+  }
+
+  const records = await listCollectionDocuments(client, keyPrefix, collection);
+
+  for (const record of records) {
+    const indexEntries = Object.entries(record.indexes);
+
+    for (const [indexName, indexValue] of indexEntries) {
+      await evalScript(
+        client,
+        ADD_INDEX_ENTRIES_SCRIPT,
+        [indexSetKey(keyPrefix, collection, indexName)],
+        [indexValue, String(record.createdAt), record.key],
+      );
+    }
+  }
+
+  await evalScript(client, SET_STRING_IF_MISSING_SCRIPT, [markerKey], ["1"]);
 }
 
 async function syncMigrationMetadataForCriteria(
@@ -2800,6 +2851,10 @@ function collectionSequenceKey(prefix: string, collection: string): string {
 
 function indexSetKey(prefix: string, collection: string, indexName: string): string {
   return `${prefix}:index:${collection}:${indexName}`;
+}
+
+function collectionIndexSyncKey(prefix: string, collection: string): string {
+  return `${prefix}:index-sync:${collection}`;
 }
 
 function migrationTargetVersionSetKey(prefix: string, collection: string): string {

--- a/tests/integration/redis-engine.test.ts
+++ b/tests/integration/redis-engine.test.ts
@@ -24,6 +24,7 @@ const isCi = process.env.CI === "true";
 const connectAttemptsRaw = Number(process.env.REDIS_CONNECT_ATTEMPTS ?? (isCi ? "180" : "60"));
 const connectDelayMsRaw = Number(process.env.REDIS_CONNECT_DELAY_MS ?? (isCi ? "1500" : "1000"));
 const keyPrefix = process.env.REDIS_TEST_PREFIX ?? createTestResourceName("nosql_odm_test");
+const INDEX_MEMBER_CREATED_AT_WIDTH = 20;
 
 type RedisClient = ReturnType<typeof createClient>;
 
@@ -50,12 +51,20 @@ function collectionOrderKey(prefix: string, collectionName: string): string {
   return `${prefix}:order:${collectionName}`;
 }
 
+function indexSetKey(prefix: string, collectionName: string, indexName: string): string {
+  return `${prefix}:index:${collectionName}:${indexName}`;
+}
+
 function migrationLockKey(prefix: string, collectionName: string): string {
   return `${prefix}:migration:lock:${collectionName}`;
 }
 
 function migrationCheckpointKey(prefix: string, collectionName: string): string {
   return `${prefix}:migration:checkpoint:${collectionName}`;
+}
+
+function encodeIndexMember(indexValue: string, createdAt: number, key: string): string {
+  return `${indexValue}\0${String(createdAt).padStart(INDEX_MEMBER_CREATED_AT_WIDTH, "0")}\0${key}`;
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -438,6 +447,36 @@ describe("redisEngine integration", () => {
     expect(range.documents.map((item) => item.key)).toEqual(["u2"]);
     expect(between.documents.map((item) => item.key)).toEqual(["u2", "u3"]);
     expect(scan.documents).toHaveLength(3);
+  });
+
+  test("indexed queries work without consulting collection order entries", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put(collection, "u2", { id: "u2" }, { byRole: "member#b" });
+    await client.del(collectionOrderKey(keyPrefix, collection));
+
+    const results = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
+
+    expect(results.documents.map((item) => item.key)).toEqual(["u1", "u2"]);
+  });
+
+  test("update and delete keep Redis index zsets in sync", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
+
+    const original = await client.zRange(indexSetKey(keyPrefix, collection, "byRole"), 0, -1);
+    expect(original).toEqual([encodeIndexMember("member#a", 1, "u1")]);
+
+    await engine.update(collection, "u1", { id: "u1" }, { byRole: "member#b" });
+
+    const updated = await client.zRange(indexSetKey(keyPrefix, collection, "byRole"), 0, -1);
+    expect(updated).toEqual([encodeIndexMember("member#b", 1, "u1")]);
+
+    await engine.delete(collection, "u1");
+
+    expect(await client.zRange(indexSetKey(keyPrefix, collection, "byRole"), 0, -1)).toEqual([]);
   });
 
   test("query pagination edge cases", async () => {

--- a/tests/unit/redis-engine.test.ts
+++ b/tests/unit/redis-engine.test.ts
@@ -1,0 +1,344 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { QueryEngine } from "../../src/engines/types";
+
+import { redisEngine } from "../../src/engines/redis";
+
+const INDEX_MEMBER_CREATED_AT_WIDTH = 20;
+
+type StoredHash = Record<string, string>;
+
+class MockRedisClient {
+  readonly hashes = new Map<string, StoredHash>();
+  readonly strings = new Map<string, string>();
+  readonly zsets = new Map<string, Map<string, number>>();
+  readonly counters = new Map<string, number>();
+  readonly zRangeCalls: string[] = [];
+  batchFetchCalls = 0;
+  indexPageCalls = 0;
+  hashReads = 0;
+
+  async get(key: string): Promise<unknown> {
+    return this.strings.get(key) ?? null;
+  }
+
+  async del(keys: string | string[]): Promise<unknown> {
+    const values = Array.isArray(keys) ? keys : [keys];
+
+    for (const key of values) {
+      this.hashes.delete(key);
+      this.strings.delete(key);
+      this.zsets.delete(key);
+    }
+
+    return values.length;
+  }
+
+  async hGetAll(key: string): Promise<unknown> {
+    this.hashReads += 1;
+    return { ...this.hashes.get(key) };
+  }
+
+  async zRange(key: string, start: number, stop: number): Promise<unknown> {
+    this.zRangeCalls.push(key);
+    const values = [...(this.zsets.get(key)?.entries() ?? [])]
+      .sort((a, b) => {
+        if (a[1] !== b[1]) {
+          return a[1] - b[1];
+        }
+
+        return a[0].localeCompare(b[0]);
+      })
+      .map(([member]) => member);
+
+    const normalizedStop = stop < 0 ? values.length + stop : stop;
+    return values.slice(start, normalizedStop + 1);
+  }
+
+  async zRem(key: string, members: string | string[]): Promise<unknown> {
+    const set = this.zsets.get(key);
+    if (!set) {
+      return 0;
+    }
+
+    let removed = 0;
+
+    for (const member of Array.isArray(members) ? members : [members]) {
+      if (set.delete(member)) {
+        removed += 1;
+      }
+    }
+
+    return removed;
+  }
+
+  async incr(key: string): Promise<unknown> {
+    const current = Number(this.counters.get(key) ?? 0) + 1;
+    this.counters.set(key, current);
+    return current;
+  }
+
+  async eval(script: string, options: { keys: string[]; arguments: string[] }): Promise<unknown> {
+    if (script.includes("local mode = ARGV[1]")) {
+      return this.applyUpsert(options.keys, options.arguments);
+    }
+
+    if (
+      script.includes("local prefix = ARGV[1]") &&
+      script.includes('local createdAt = redis.call("HGET", KEYS[1], "createdAt")')
+    ) {
+      return this.applyDelete(options.keys, options.arguments);
+    }
+
+    if (script.includes("HMGET") && script.includes("documentHashKey(KEYS[1], KEYS[2], key)")) {
+      this.batchFetchCalls += 1;
+      return this.fetchBatchDocuments(options.keys, options.arguments);
+    }
+
+    if (script.includes("ZREVRANGEBYLEX") && script.includes("ZRANGEBYLEX")) {
+      this.indexPageCalls += 1;
+      return this.fetchIndexPage(options.keys[0]!, options.arguments);
+    }
+
+    throw new Error(`Unsupported mock Redis script: ${script.slice(0, 40)}`);
+  }
+
+  private applyUpsert(keys: string[], args: string[]): [number, number] {
+    const [documentKey, orderKey] = keys;
+    const [
+      mode,
+      prefix,
+      collection,
+      key,
+      createdAtArg,
+      docJson,
+      indexesJson,
+      targetVersion,
+      versionState,
+      indexSignature,
+      indexSignatureToken,
+      expectedWriteVersionRaw,
+      uniqueIndexesProvided,
+      nextUniqueIndexesJson,
+    ] = args;
+    const existing = this.hashes.get(documentKey!);
+
+    if (mode === "create" && existing) {
+      return [0, 0];
+    }
+
+    if (mode === "update" && !existing) {
+      return [0, 0];
+    }
+
+    const previousWriteVersion = Number(existing?.writeVersion ?? "1");
+    if (
+      mode === "conditional" &&
+      (!existing || previousWriteVersion !== Number(expectedWriteVersionRaw))
+    ) {
+      return [2, 0];
+    }
+
+    const createdAt = existing?.createdAt ?? createdAtArg!;
+    const previousIndexes = parseIndexes(existing?.indexes ?? "{}");
+    const nextIndexes = parseIndexes(indexesJson!);
+
+    for (const [indexName, indexValue] of Object.entries(previousIndexes)) {
+      this.zsets
+        .get(indexSetKey(prefix!, collection!, indexName))
+        ?.delete(encodeIndexMember(indexValue, Number(createdAt), key!));
+    }
+
+    for (const [indexName, indexValue] of Object.entries(nextIndexes)) {
+      this.zAdd(
+        indexSetKey(prefix!, collection!, indexName),
+        0,
+        encodeIndexMember(indexValue, Number(createdAt), key!),
+      );
+    }
+
+    this.zAdd(orderKey!, Number(createdAt), key!);
+
+    this.hashes.set(documentKey!, {
+      createdAt,
+      writeVersion: String(existing ? previousWriteVersion + 1 : 1),
+      doc: docJson!,
+      indexes: indexesJson!,
+      uniqueIndexes:
+        uniqueIndexesProvided === "1" ? nextUniqueIndexesJson! : (existing?.uniqueIndexes ?? "{}"),
+      migrationTargetVersion: targetVersion!,
+      migrationVersionState: versionState!,
+      migrationIndexSignature: indexSignature!,
+      migrationIndexSignatureToken: indexSignatureToken!,
+    });
+
+    return [1, existing ? previousWriteVersion + 1 : 1];
+  }
+
+  private applyDelete(keys: string[], args: string[]): number {
+    const [documentKey, orderKey] = keys;
+    const [prefix, collection, key] = args;
+    const existing = this.hashes.get(documentKey!);
+
+    if (existing) {
+      const storedIndexes = existing["indexes"] ?? "{}";
+
+      for (const [indexName, indexValue] of Object.entries(parseIndexes(storedIndexes))) {
+        this.zsets
+          .get(indexSetKey(prefix!, collection!, indexName))
+          ?.delete(encodeIndexMember(indexValue, Number(existing.createdAt), key!));
+      }
+    }
+
+    this.hashes.delete(documentKey!);
+    this.zsets.get(orderKey!)?.delete(key!);
+    return 1;
+  }
+
+  private fetchBatchDocuments(keys: string[], documentKeys: string[]): string[] {
+    const [prefix, collection] = keys;
+    const results: string[] = [];
+
+    for (const key of documentKeys) {
+      const record = this.hashes.get(documentHashKey(prefix!, collection!, key));
+
+      if (!record) {
+        continue;
+      }
+
+      results.push(
+        JSON.stringify({
+          key,
+          createdAt: record.createdAt,
+          writeVersion: record.writeVersion,
+          doc: record.doc,
+          indexes: record.indexes,
+          migrationTargetVersion: record.migrationTargetVersion,
+          migrationVersionState: record.migrationVersionState,
+          migrationIndexSignature: record.migrationIndexSignature,
+        }),
+      );
+    }
+
+    return results;
+  }
+
+  private fetchIndexPage(key: string, args: string[]): string[] {
+    const [sort, boundA, boundB, countRaw] = args;
+    const count = Number(countRaw);
+    const values = [...(this.zsets.get(key)?.keys() ?? [])].sort((a, b) => a.localeCompare(b));
+    const filtered = values.filter((value) =>
+      sort === "desc"
+        ? matchesLexBound(value, boundA!, true) && matchesLexBound(value, boundB!, false)
+        : matchesLexBound(value, boundA!, false) && matchesLexBound(value, boundB!, true),
+    );
+    const ordered = sort === "desc" ? filtered.reverse() : filtered;
+    return ordered.slice(0, count);
+  }
+
+  private zAdd(key: string, score: number, member: string): void {
+    let set = this.zsets.get(key);
+
+    if (!set) {
+      set = new Map();
+      this.zsets.set(key, set);
+    }
+
+    set.set(member, score);
+  }
+}
+
+let client: MockRedisClient;
+let engine: QueryEngine<never>;
+
+beforeEach(() => {
+  client = new MockRedisClient();
+  engine = redisEngine({
+    client,
+    keyPrefix: "test",
+  });
+});
+
+describe("redisEngine", () => {
+  test("batchGet uses a single batched document fetch", async () => {
+    await engine.put("users", "u1", { id: "u1" }, { primary: "u1" });
+    await engine.put("users", "u2", { id: "u2" }, { primary: "u2" });
+
+    client.batchFetchCalls = 0;
+    client.hashReads = 0;
+
+    const results = await engine.batchGet("users", ["u2", "u1", "u2"]);
+
+    expect(results.map((item) => item.key)).toEqual(["u2", "u1", "u2"]);
+    expect(client.batchFetchCalls).toBe(1);
+    expect(client.hashReads).toBe(0);
+  });
+
+  test("sorted indexed query does not fall back to collection order scans", async () => {
+    await engine.put("users", "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put("users", "u2", { id: "u2" }, { byRole: "member#b" });
+
+    client.zRangeCalls.length = 0;
+
+    const results = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
+
+    expect(results.documents.map((item) => item.key)).toEqual(["u1", "u2"]);
+    expect(client.indexPageCalls).toBeGreaterThan(0);
+    expect(client.zRangeCalls).not.toContain(collectionOrderKey("test", "users"));
+  });
+
+  test("update and delete keep index zsets in sync", async () => {
+    await engine.put("users", "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.update("users", "u1", { id: "u1" }, { byRole: "member#b" });
+
+    expect([...client.zsets.get(indexSetKey("test", "users", "byRole"))!.keys()]).toEqual([
+      encodeIndexMember("member#b", 1, "u1"),
+    ]);
+
+    await engine.delete("users", "u1");
+
+    expect([
+      ...(client.zsets.get(indexSetKey("test", "users", "byRole")) ?? new Map()).keys(),
+    ]).toEqual([]);
+  });
+});
+
+function documentHashKey(prefix: string, collection: string, key: string): string {
+  return `${prefix}:doc:${collection}:${key}`;
+}
+
+function collectionOrderKey(prefix: string, collection: string): string {
+  return `${prefix}:order:${collection}`;
+}
+
+function indexSetKey(prefix: string, collection: string, indexName: string): string {
+  return `${prefix}:index:${collection}:${indexName}`;
+}
+
+function encodeIndexMember(indexValue: string, createdAt: number, key: string): string {
+  return `${indexValue}\0${String(createdAt).padStart(INDEX_MEMBER_CREATED_AT_WIDTH, "0")}\0${key}`;
+}
+
+function parseIndexes(raw: string): Record<string, string> {
+  return JSON.parse(raw) as Record<string, string>;
+}
+
+function matchesLexBound(value: string, bound: string, upper: boolean): boolean {
+  if (bound === "-" || bound === "+") {
+    return true;
+  }
+
+  const inclusive = bound.startsWith("[");
+  const target = bound.slice(1);
+  const comparison = value.localeCompare(target);
+
+  if (upper) {
+    return inclusive ? comparison <= 0 : comparison < 0;
+  }
+
+  return inclusive ? comparison >= 0 : comparison > 0;
+}

--- a/tests/unit/redis-engine.test.ts
+++ b/tests/unit/redis-engine.test.ts
@@ -17,6 +17,7 @@ class MockRedisClient {
   batchFetchCalls = 0;
   indexPageCalls = 0;
   hashReads = 0;
+  syncMarkerWrites = 0;
 
   async get(key: string): Promise<unknown> {
     return this.strings.get(key) ?? null;
@@ -93,6 +94,14 @@ class MockRedisClient {
     if (script.includes("HMGET") && script.includes("documentHashKey(KEYS[1], KEYS[2], key)")) {
       this.batchFetchCalls += 1;
       return this.fetchBatchDocuments(options.keys, options.arguments);
+    }
+
+    if (script.includes('redis.call("ZADD", KEYS[1], 0, ARGV[i]')) {
+      return this.addIndexEntries(options.keys[0]!, options.arguments);
+    }
+
+    if (script.includes('redis.call("SET", KEYS[1], ARGV[1])')) {
+      return this.setStringIfMissing(options.keys[0]!, options.arguments[0]!);
     }
 
     if (script.includes("ZREVRANGEBYLEX") && script.includes("ZRANGEBYLEX")) {
@@ -206,6 +215,15 @@ class MockRedisClient {
         continue;
       }
 
+      if (
+        record.createdAt === undefined ||
+        record.writeVersion === undefined ||
+        record.doc === undefined ||
+        record.indexes === undefined
+      ) {
+        continue;
+      }
+
       results.push(
         JSON.stringify({
           key,
@@ -234,6 +252,24 @@ class MockRedisClient {
     );
     const ordered = sort === "desc" ? filtered.reverse() : filtered;
     return ordered.slice(0, count);
+  }
+
+  private addIndexEntries(key: string, args: string[]): number {
+    for (let i = 0; i < args.length; i += 3) {
+      this.zAdd(key, 0, encodeIndexMember(args[i]!, Number(args[i + 1]!), args[i + 2]!));
+    }
+
+    return 1;
+  }
+
+  private setStringIfMissing(key: string, value: string): number {
+    if (!this.strings.has(key)) {
+      this.strings.set(key, value);
+      this.syncMarkerWrites += 1;
+      return 1;
+    }
+
+    return 0;
   }
 
   private zAdd(key: string, score: number, member: string): void {
@@ -278,8 +314,13 @@ describe("redisEngine", () => {
     await engine.put("users", "u1", { id: "u1" }, { byRole: "member#a" });
     await engine.put("users", "u2", { id: "u2" }, { byRole: "member#b" });
 
-    client.zRangeCalls.length = 0;
+    await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
 
+    client.zRangeCalls.length = 0;
     const results = await engine.query("users", {
       index: "byRole",
       filter: { value: { $begins: "member#" } },
@@ -289,6 +330,45 @@ describe("redisEngine", () => {
     expect(results.documents.map((item) => item.key)).toEqual(["u1", "u2"]);
     expect(client.indexPageCalls).toBeGreaterThan(0);
     expect(client.zRangeCalls).not.toContain(collectionOrderKey("test", "users"));
+  });
+
+  test("sorted indexed query backfills legacy documents before using the index set", async () => {
+    client.hashes.set(documentHashKey("test", "users", "u1"), {
+      createdAt: "1",
+      writeVersion: "1",
+      doc: JSON.stringify({ id: "u1" }),
+      indexes: JSON.stringify({ byRole: "member#a" }),
+      uniqueIndexes: "{}",
+      migrationTargetVersion: "0",
+      migrationVersionState: "unknown",
+      migrationIndexSignature: "",
+      migrationIndexSignatureToken: "__null__",
+    });
+    client.zsets.set(collectionOrderKey("test", "users"), new Map([["u1", 1]]));
+
+    const results = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
+
+    expect(results.documents.map((item) => item.key)).toEqual(["u1"]);
+    expect([...client.zsets.get(indexSetKey("test", "users", "byRole"))!.keys()]).toEqual([
+      encodeIndexMember("member#a", 1, "u1"),
+    ]);
+    expect(client.strings.get(collectionIndexSyncKey("test", "users"))).toBe("1");
+  });
+
+  test("batchGet skips malformed records missing writeVersion", async () => {
+    client.hashes.set(documentHashKey("test", "users", "u1"), {
+      createdAt: "1",
+      doc: JSON.stringify({ id: "u1" }),
+      indexes: JSON.stringify({ primary: "u1" }),
+    });
+
+    const results = await engine.batchGet("users", ["u1"]);
+
+    expect(results).toEqual([]);
   });
 
   test("update and delete keep index zsets in sync", async () => {
@@ -317,6 +397,10 @@ function collectionOrderKey(prefix: string, collection: string): string {
 
 function indexSetKey(prefix: string, collection: string, indexName: string): string {
   return `${prefix}:index:${collection}:${indexName}`;
+}
+
+function collectionIndexSyncKey(prefix: string, collection: string): string {
+  return `${prefix}:index-sync:${collection}`;
 }
 
 function encodeIndexMember(indexValue: string, createdAt: number, key: string): string {

--- a/tests/unit/redis-engine.test.ts
+++ b/tests/unit/redis-engine.test.ts
@@ -359,6 +359,41 @@ describe("redisEngine", () => {
     expect(client.strings.get(collectionIndexSyncKey("test", "users"))).toBe("1");
   });
 
+  test("sorted indexed pagination keeps advancing from the last collected valid member", async () => {
+    await engine.put("users", "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put("users", "u2", { id: "u2" }, { byRole: "member#b" });
+    await engine.put("users", "u3", { id: "u3" }, { byRole: "member#c" });
+
+    client.zsets
+      .get(indexSetKey("test", "users", "byRole"))!
+      .set(encodeIndexMember("member#z", 999, "ghost"), 0);
+
+    const page1 = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+    });
+    const page2 = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+      cursor: page1.cursor ?? undefined,
+    });
+    const page3 = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+      cursor: page2.cursor ?? undefined,
+    });
+
+    expect(page1.documents.map((item) => item.key)).toEqual(["u1"]);
+    expect(page2.documents.map((item) => item.key)).toEqual(["u2"]);
+    expect(page3.documents.map((item) => item.key)).toEqual(["u3"]);
+  });
+
   test("batchGet skips malformed records missing writeVersion", async () => {
     client.hashes.set(documentHashKey("test", "users", "u1"), {
       createdAt: "1",


### PR DESCRIPTION
## Summary
- push Redis indexed queries down into Redis-maintained lexicographic index sorted sets instead of loading and filtering the full collection in memory
- batch Redis `batchGet` and `batchGetWithMetadata` document reads through a single Lua script call
- keep Redis index entries in sync on create, update, and delete, and add a changeset plus Redis-focused regression coverage

## Why
Issue #118 identified two expensive Redis paths:
- indexed queries still loaded the full collection before filtering
- batched reads fetched each key one-by-one, paying a round trip per document

This change makes the Redis adapter scale query work with matched results instead of total collection size for supported index filters, and reduces batched read overhead to a single Redis script call.

## What changed
- added Redis-maintained per-index sorted sets keyed by resolved index name
- encoded index members as `indexValue + createdAt + key` so Redis lexicographic range queries can support equality, prefix, and comparison filters with stable pagination
- added an indexed query path for sortable `index` + `filter` queries, with safe scan fallback when the filter shape cannot be pushed down cleanly
- replaced per-key batch reads with a batched document fetch script shared by `batchGet` and `batchGetWithMetadata`
- added unit coverage for batched fetch behavior, sorted index-query pushdown, and index-set maintenance
- added Redis integration coverage for raw index-set maintenance and indexed-query independence from collection-order scans

## Impact
- Redis queries on common index filters avoid full-collection client-side scans
- Redis batched reads avoid one network round trip per key
- index maintenance stays consistent across updates and deletes, which keeps the new query path correct over time

## Validation
- `bun test ./tests/unit/redis-engine.test.ts`
- `bun run typecheck`
- `bun run fmt`
- `bun run lint` (passes with existing unrelated warnings in MySQL/DynamoDB/SQLite tests)

## Notes
- I could not run `bun run test:integration:redis` locally because the Docker daemon was unavailable when attempting `bun run services:up:redis`.
- Closes #118
