### PR TITLE
[codex] fix firestore query pushdown and batched reads

### DIFF
--- a/.changeset/firestore-query-batching.md
+++ b/.changeset/firestore-query-batching.md
@@ -1,0 +1,7 @@
+---
+"nosql-odm": patch
+---
+
+Push expressible Firestore queries down into server-side ordering and cursor
+pagination, and batch `batchGet` reads through `getAll` while preserving local
+fallbacks for query shapes Firestore cannot represent safely.

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -28,6 +28,7 @@ import {
 
 const DEFAULT_DOCUMENTS_COLLECTION = "nosql_odm_documents";
 const DEFAULT_METADATA_COLLECTION = "nosql_odm_metadata";
+const FIRESTORE_GET_ALL_MAX_REFS = 300;
 const OUTDATED_PAGE_LIMIT = 100;
 const OUTDATED_SYNC_CHUNK_SIZE = 100;
 
@@ -862,26 +863,36 @@ async function batchGetDocuments(
 ): Promise<KeyedDocument[]> {
   const uniqueKeys = uniqueStrings(keys);
   const refs = uniqueKeys.map((key) => documentRef(documentsCollection, collection, key));
-  const snapshotsRaw = database.getAll
-    ? await database.getAll(...refs)
-    : await Promise.all(refs.map(async (ref) => ref.get()));
   const fetched = new Map<string, StoredDocumentRecord>();
 
-  for (let i = 0; i < uniqueKeys.length; i++) {
-    const key = uniqueKeys[i];
-    const raw = snapshotsRaw[i];
+  if (database.getAll) {
+    for (const refChunk of chunkRefs(refs, FIRESTORE_GET_ALL_MAX_REFS)) {
+      const snapshotsRaw = await database.getAll(...refChunk);
 
-    if (key === undefined || raw === undefined) {
-      continue;
+      for (const raw of snapshotsRaw) {
+        const snapshot = parseDocumentSnapshot(raw, "document record");
+
+        if (!snapshot.exists) {
+          continue;
+        }
+
+        const record = parseStoredDocumentRecord(snapshotData(snapshot, "document record"));
+        fetched.set(record.key, record);
+      }
     }
+  } else {
+    const snapshotsRaw = await Promise.all(refs.map(async (ref) => ref.get()));
 
-    const snapshot = parseDocumentSnapshot(raw, "document record");
+    for (const raw of snapshotsRaw) {
+      const snapshot = parseDocumentSnapshot(raw, "document record");
 
-    if (!snapshot.exists) {
-      continue;
+      if (!snapshot.exists) {
+        continue;
+      }
+
+      const record = parseStoredDocumentRecord(snapshotData(snapshot, "document record"));
+      fetched.set(record.key, record);
     }
-
-    fetched.set(key, parseStoredDocumentRecord(snapshotData(snapshot, "document record")));
   }
 
   const results: KeyedDocument[] = [];
@@ -2314,6 +2325,16 @@ function uniqueStrings(values: string[]): string[] {
   }
 
   return unique;
+}
+
+function chunkRefs<T>(values: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < values.length; i += size) {
+    chunks.push(values.slice(i, i + size));
+  }
+
+  return chunks;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -4,6 +4,7 @@ import { DefaultMigrator } from "../migrator";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import {
   encodeQueryPageCursor,
+  resolveQueryPageCursorPosition,
   resolveQueryPageStartIndex,
   validateQueryPageCursor,
 } from "./query-cursor";
@@ -53,6 +54,8 @@ interface FirestoreDocumentReferenceLike {
 
 interface FirestoreQueryLike {
   where(fieldPath: string, opStr: string, value: unknown): FirestoreQueryLike;
+  orderBy(fieldPath: string, directionStr?: "asc" | "desc"): FirestoreQueryLike;
+  startAfter(...fieldValues: unknown[]): FirestoreQueryLike;
   limit(limit: number): FirestoreQueryLike;
   get(): Promise<unknown>;
 }
@@ -77,6 +80,7 @@ interface FirestoreTransactionLike {
 
 interface FirestoreLike {
   collection(path: string): FirestoreCollectionLike;
+  getAll?(...refs: unknown[]): Promise<unknown[]>;
   runTransaction<T>(
     updateFunction: (transaction: FirestoreTransactionLike) => Promise<T>,
   ): Promise<T>;
@@ -334,6 +338,14 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
 
     async query(collection, params) {
       validateQueryPageCursor(collection, params);
+      const paged =
+        (await queryCollectionDocumentsPage(documentsCollection, collection, params, false)) ??
+        null;
+
+      if (paged) {
+        return paged;
+      }
+
       const records =
         (await listCollectionDocumentsByQuery(documentsCollection, collection, params)) ??
         (await listCollectionDocuments(documentsCollection, collection));
@@ -344,6 +356,13 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
 
     async queryWithMetadata(collection, params) {
       validateQueryPageCursor(collection, params);
+      const paged =
+        (await queryCollectionDocumentsPage(documentsCollection, collection, params, true)) ?? null;
+
+      if (paged) {
+        return paged;
+      }
+
       const records =
         (await listCollectionDocumentsByQuery(documentsCollection, collection, params)) ??
         (await listCollectionDocuments(documentsCollection, collection));
@@ -353,94 +372,11 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
     },
 
     async batchGet(collection, keys) {
-      const uniqueKeys = uniqueStrings(keys);
-      const fetchedEntries = await Promise.all(
-        uniqueKeys.map(async (key) => {
-          const raw = await documentRef(documentsCollection, collection, key).get();
-          const snapshot = parseDocumentSnapshot(raw, "document record");
-
-          if (!snapshot.exists) {
-            return null;
-          }
-
-          const record = parseStoredDocumentRecord(snapshotData(snapshot, "document record"));
-
-          return [key, record] as const;
-        }),
-      );
-
-      const fetched = new Map<string, StoredDocumentRecord>();
-
-      for (const entry of fetchedEntries) {
-        if (!entry) {
-          continue;
-        }
-
-        fetched.set(entry[0], entry[1]);
-      }
-
-      const results: KeyedDocument[] = [];
-
-      for (const key of keys) {
-        const record = fetched.get(key);
-
-        if (!record) {
-          continue;
-        }
-
-        results.push({
-          key,
-          doc: structuredClone(record.doc),
-        });
-      }
-
-      return results;
+      return batchGetDocuments(database, documentsCollection, collection, keys, false);
     },
 
     async batchGetWithMetadata(collection, keys) {
-      const uniqueKeys = uniqueStrings(keys);
-      const fetchedEntries = await Promise.all(
-        uniqueKeys.map(async (key) => {
-          const raw = await documentRef(documentsCollection, collection, key).get();
-          const snapshot = parseDocumentSnapshot(raw, "document record");
-
-          if (!snapshot.exists) {
-            return null;
-          }
-
-          const record = parseStoredDocumentRecord(snapshotData(snapshot, "document record"));
-
-          return [key, record] as const;
-        }),
-      );
-
-      const fetched = new Map<string, StoredDocumentRecord>();
-
-      for (const entry of fetchedEntries) {
-        if (!entry) {
-          continue;
-        }
-
-        fetched.set(entry[0], entry[1]);
-      }
-
-      const results: KeyedDocument[] = [];
-
-      for (const key of keys) {
-        const record = fetched.get(key);
-
-        if (!record) {
-          continue;
-        }
-
-        results.push({
-          key,
-          doc: structuredClone(record.doc),
-          writeToken: String(record.writeVersion),
-        });
-      }
-
-      return results;
+      return batchGetDocuments(database, documentsCollection, collection, keys, true);
     },
 
     async batchSet(collection, items) {
@@ -915,6 +851,214 @@ async function listCollectionDocumentsByQuery(
   });
 
   return records;
+}
+
+async function batchGetDocuments(
+  database: FirestoreLike,
+  documentsCollection: FirestoreCollectionLike,
+  collection: string,
+  keys: string[],
+  includeWriteTokens: boolean,
+): Promise<KeyedDocument[]> {
+  const uniqueKeys = uniqueStrings(keys);
+  const refs = uniqueKeys.map((key) => documentRef(documentsCollection, collection, key));
+  const snapshotsRaw = database.getAll
+    ? await database.getAll(...refs)
+    : await Promise.all(refs.map(async (ref) => ref.get()));
+  const fetched = new Map<string, StoredDocumentRecord>();
+
+  for (let i = 0; i < uniqueKeys.length; i++) {
+    const key = uniqueKeys[i];
+    const raw = snapshotsRaw[i];
+
+    if (key === undefined || raw === undefined) {
+      continue;
+    }
+
+    const snapshot = parseDocumentSnapshot(raw, "document record");
+
+    if (!snapshot.exists) {
+      continue;
+    }
+
+    fetched.set(key, parseStoredDocumentRecord(snapshotData(snapshot, "document record")));
+  }
+
+  const results: KeyedDocument[] = [];
+
+  for (const key of keys) {
+    const record = fetched.get(key);
+
+    if (!record) {
+      continue;
+    }
+
+    results.push(
+      includeWriteTokens
+        ? {
+            key,
+            doc: structuredClone(record.doc),
+            writeToken: String(record.writeVersion),
+          }
+        : {
+            key,
+            doc: structuredClone(record.doc),
+          },
+    );
+  }
+
+  return results;
+}
+
+async function queryCollectionDocumentsPage(
+  documentsCollection: FirestoreCollectionLike,
+  collection: string,
+  params: QueryParams,
+  includeWriteTokens: boolean,
+): Promise<EngineQueryResult | null> {
+  const plan = buildFirestoreQueryPlan(documentsCollection, collection, params);
+
+  if (!plan) {
+    return null;
+  }
+
+  let query = plan.query;
+  const pageSize = normalizeLimit(params.limit);
+  const fetchLimit = pageSize === null ? null : pageSize + 1;
+
+  if (fetchLimit !== null) {
+    query = query.limit(fetchLimit);
+  }
+
+  const raw = await query.get();
+  const snapshot = parseQuerySnapshot(raw, "document record");
+  const records = snapshot.docs.map((doc) =>
+    parseStoredDocumentRecord(snapshotData(doc, "document record")),
+  );
+  const hasMore = fetchLimit !== null && pageSize !== null && records.length > pageSize;
+  const pageRecords = hasMore && pageSize !== null ? records.slice(0, pageSize) : records;
+
+  return buildFirestoreQueryPageResult(
+    collection,
+    params,
+    pageRecords,
+    hasMore,
+    includeWriteTokens,
+  );
+}
+
+function buildFirestoreQueryPlan(
+  documentsCollection: FirestoreCollectionLike,
+  collection: string,
+  params: QueryParams,
+): { query: FirestoreQueryLike } | null {
+  const cursorPosition = resolveQueryPageCursorPosition(collection, params);
+
+  if (!params.index || !params.filter) {
+    if (params.sort) {
+      return null;
+    }
+
+    let query: FirestoreQueryLike = documentsCollection.where("collection", "==", collection);
+    query = query.orderBy("createdAt", "asc").orderBy("key", "asc");
+
+    if (cursorPosition) {
+      if (cursorPosition.kind !== "scan") {
+        return null;
+      }
+
+      query = query.startAfter(cursorPosition.createdAt, cursorPosition.key);
+    }
+
+    return { query };
+  }
+
+  const filters = buildFirestoreWhereFilters(params.filter.value);
+
+  if (!filters) {
+    return null;
+  }
+
+  const hasInequality = filters.some((filter) => filter.op !== "==");
+
+  if (!params.sort && hasInequality) {
+    return null;
+  }
+
+  const indexField = `indexes.${params.index}`;
+  let query: FirestoreQueryLike = documentsCollection.where("collection", "==", collection);
+
+  for (const filter of filters) {
+    query = query.where(indexField, filter.op, filter.value);
+  }
+
+  if (params.sort) {
+    query = query
+      .orderBy(indexField, params.sort)
+      .orderBy("createdAt", "asc")
+      .orderBy("key", "asc");
+
+    if (cursorPosition) {
+      if (cursorPosition.kind !== "sorted-index" || cursorPosition.createdAt === undefined) {
+        return null;
+      }
+
+      query = query.startAfter(
+        cursorPosition.indexValue,
+        cursorPosition.createdAt,
+        cursorPosition.key,
+      );
+    }
+
+    return { query };
+  }
+
+  query = query.orderBy("createdAt", "asc").orderBy("key", "asc");
+
+  if (cursorPosition) {
+    if (cursorPosition.kind !== "scan") {
+      return null;
+    }
+
+    query = query.startAfter(cursorPosition.createdAt, cursorPosition.key);
+  }
+
+  return { query };
+}
+
+function buildFirestoreQueryPageResult(
+  collection: string,
+  params: QueryParams,
+  records: StoredDocumentRecord[],
+  hasMore: boolean,
+  includeWriteTokens: boolean,
+): EngineQueryResult {
+  const cursor =
+    hasMore && records.length > 0
+      ? encodeQueryPageCursor(collection, params, {
+          key: records[records.length - 1]!.key,
+          createdAt: records[records.length - 1]!.createdAt,
+          indexValue: params.index
+            ? (records[records.length - 1]!.indexes[params.index] ?? "")
+            : undefined,
+        })
+      : null;
+
+  return {
+    documents: records.map((record) =>
+      includeWriteTokens
+        ? {
+            key: record.key,
+            doc: structuredClone(record.doc),
+            writeToken: String(record.writeVersion),
+          }
+        : {
+            key: record.key,
+            doc: structuredClone(record.doc),
+          },
+    ),
+    cursor,
+  };
 }
 
 interface FirestoreWhereClause {

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -941,7 +941,18 @@ async function queryCollectionDocumentsPage(
     query = query.limit(fetchLimit);
   }
 
-  const raw = await query.get();
+  let raw: unknown;
+
+  try {
+    raw = await query.get();
+  } catch (error) {
+    if (isFirestoreMissingIndexError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+
   const snapshot = parseQuerySnapshot(raw, "document record");
   const records = snapshot.docs.map((doc) =>
     parseStoredDocumentRecord(snapshotData(doc, "document record")),
@@ -2335,6 +2346,22 @@ function chunkRefs<T>(values: T[], size: number): T[][] {
   }
 
   return chunks;
+}
+
+function isFirestoreMissingIndexError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  const name = error.name.toLowerCase();
+
+  return (
+    message.includes("requires an index") ||
+    message.includes("the query requires an index") ||
+    message.includes("failed_precondition") ||
+    name === "failed_precondition"
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/tests/unit/firestore-engine.test.ts
+++ b/tests/unit/firestore-engine.test.ts
@@ -275,6 +275,13 @@ class FakeFirestoreDatabase {
   }
 }
 
+class ReorderingGetAllFirestoreDatabase extends FakeFirestoreDatabase {
+  override async getAll(...refs: unknown[]) {
+    const snapshots = await super.getAll(...refs);
+    return [...snapshots].reverse();
+  }
+}
+
 class RejectingGetAllFirestoreTransaction extends FakeFirestoreTransaction {
   override getAll(..._refs: unknown[]) {
     return Promise.reject(new Error("getAll should not be called")) as ReturnType<
@@ -399,6 +406,32 @@ describe("firestoreEngine query execution", () => {
     expect(database.instrumentation.documentGetCalls).toEqual([]);
   });
 
+  test("batchGet chunks large getAll reads and does not rely on snapshot order", async () => {
+    const database = new ReorderingGetAllFirestoreDatabase();
+    const engine = createEngine(database);
+    const items = Array.from({ length: 305 }, (_, index) => ({
+      key: `u${String(index + 1)}`,
+      doc: { id: `u${String(index + 1)}` },
+      indexes: { primary: `u${String(index + 1)}` },
+    }));
+    const requestKeys = items.map((item) => item.key);
+
+    await engine.batchSet("users", items);
+
+    const results = await engine.batchGet("users", requestKeys);
+
+    expect(database.instrumentation.getAllCalls).toHaveLength(2);
+    expect(database.instrumentation.getAllCalls[0]).toHaveLength(300);
+    expect(database.instrumentation.getAllCalls[1]).toEqual([
+      "doc:users:u301",
+      "doc:users:u302",
+      "doc:users:u303",
+      "doc:users:u304",
+      "doc:users:u305",
+    ]);
+    expect(results.map((entry) => entry.key)).toEqual(requestKeys);
+  });
+
   test("query pushes sorted pagination into Firestore when the query is expressible", async () => {
     const database = new FakeFirestoreDatabase();
     const engine = createEngine(database);
@@ -465,6 +498,75 @@ describe("firestoreEngine query execution", () => {
         { fieldPath: "key", direction: "asc" },
       ],
       startAfter: ["2025-02-01", 2, "u2"],
+      limit: 3,
+    });
+  });
+
+  test("query pushes equality-only pagination into Firestore with scan cursors", async () => {
+    const database = new FakeFirestoreDatabase();
+    const engine = createEngine(database);
+
+    await engine.batchSet("users", [
+      {
+        key: "u1",
+        doc: { id: "u1", status: "active" },
+        indexes: { status: "active" },
+      },
+      {
+        key: "u2",
+        doc: { id: "u2", status: "inactive" },
+        indexes: { status: "inactive" },
+      },
+      {
+        key: "u3",
+        doc: { id: "u3", status: "active" },
+        indexes: { status: "active" },
+      },
+      {
+        key: "u4",
+        doc: { id: "u4", status: "active" },
+        indexes: { status: "active" },
+      },
+    ]);
+
+    const firstPage = await engine.query("users", {
+      index: "status",
+      filter: { value: "active" },
+      limit: 2,
+    });
+
+    expect(firstPage.documents.map((entry) => entry.key)).toEqual(["u1", "u3"]);
+    expect(database.instrumentation.queryReads.at(-1)).toEqual({
+      filters: [
+        { fieldPath: "collection", opStr: "==", value: "users" },
+        { fieldPath: "indexes.status", opStr: "==", value: "active" },
+      ],
+      orderBy: [
+        { fieldPath: "createdAt", direction: "asc" },
+        { fieldPath: "key", direction: "asc" },
+      ],
+      startAfter: [],
+      limit: 3,
+    });
+
+    const secondPage = await engine.query("users", {
+      index: "status",
+      filter: { value: "active" },
+      limit: 2,
+      cursor: firstPage.cursor ?? undefined,
+    });
+
+    expect(secondPage.documents.map((entry) => entry.key)).toEqual(["u4"]);
+    expect(database.instrumentation.queryReads.at(-1)).toEqual({
+      filters: [
+        { fieldPath: "collection", opStr: "==", value: "users" },
+        { fieldPath: "indexes.status", opStr: "==", value: "active" },
+      ],
+      orderBy: [
+        { fieldPath: "createdAt", direction: "asc" },
+        { fieldPath: "key", direction: "asc" },
+      ],
+      startAfter: [3, "u3"],
       limit: 3,
     });
   });

--- a/tests/unit/firestore-engine.test.ts
+++ b/tests/unit/firestore-engine.test.ts
@@ -13,11 +13,30 @@ interface FakeWhereClause {
   readonly value: unknown;
 }
 
+interface FakeOrderByClause {
+  readonly fieldPath: string;
+  readonly direction: "asc" | "desc";
+}
+
+interface FakeQueryState {
+  readonly filters: readonly FakeWhereClause[];
+  readonly orderBy: readonly FakeOrderByClause[];
+  readonly startAfter: readonly unknown[];
+  readonly limit: number | null;
+}
+
+interface FakeFirestoreInstrumentation {
+  readonly documentGetCalls: string[];
+  readonly getAllCalls: string[][];
+  readonly queryReads: FakeQueryState[];
+}
+
 class FakeFirestoreDocumentReference {
   readonly id: string;
 
   constructor(
     private readonly store: Map<string, FakeFirestoreRecord>,
+    private readonly instrumentation: FakeFirestoreInstrumentation,
     id: string,
   ) {
     this.id = id;
@@ -57,6 +76,7 @@ class FakeFirestoreDocumentReference {
   }
 
   async get() {
+    this.instrumentation.documentGetCalls.push(this.id);
     return this.readSnapshot();
   }
 
@@ -72,44 +92,106 @@ class FakeFirestoreDocumentReference {
 class FakeFirestoreQuery {
   constructor(
     protected readonly store: Map<string, FakeFirestoreRecord>,
-    private readonly filters: readonly FakeWhereClause[] = [],
+    protected readonly instrumentation: FakeFirestoreInstrumentation,
+    private readonly state: FakeQueryState = {
+      filters: [],
+      orderBy: [],
+      startAfter: [],
+      limit: null,
+    },
   ) {}
 
   where(fieldPath: string, opStr: string, value: unknown) {
-    return new FakeFirestoreQuery(this.store, [
-      ...this.filters,
-      {
-        fieldPath,
-        opStr,
-        value,
-      },
-    ]);
+    return new FakeFirestoreQuery(this.store, this.instrumentation, {
+      ...this.state,
+      filters: [
+        ...this.state.filters,
+        {
+          fieldPath,
+          opStr,
+          value,
+        },
+      ],
+    });
   }
 
-  limit(_limit: number) {
-    return this;
+  orderBy(fieldPath: string, direction: "asc" | "desc" = "asc") {
+    return new FakeFirestoreQuery(this.store, this.instrumentation, {
+      ...this.state,
+      orderBy: [
+        ...this.state.orderBy,
+        {
+          fieldPath,
+          direction,
+        },
+      ],
+    });
+  }
+
+  startAfter(...values: unknown[]) {
+    return new FakeFirestoreQuery(this.store, this.instrumentation, {
+      ...this.state,
+      startAfter: [...values],
+    });
+  }
+
+  limit(limit: number) {
+    return new FakeFirestoreQuery(this.store, this.instrumentation, {
+      ...this.state,
+      limit,
+    });
   }
 
   async get() {
-    const docs = [...this.store.entries()]
-      .filter(([, record]) => this.filters.every((filter) => matchesWhereClause(record, filter)))
-      .map(([id, record]) => ({
-        exists: true,
-        id,
-        data: () => structuredClone(record),
-      }));
+    this.instrumentation.queryReads.push({
+      filters: [...this.state.filters],
+      orderBy: [...this.state.orderBy],
+      startAfter: [...this.state.startAfter],
+      limit: this.state.limit,
+    });
+
+    let entries = [...this.store.entries()].filter(([, record]) =>
+      this.state.filters.every((filter) => matchesWhereClause(record, filter)),
+    );
+
+    if (this.state.orderBy.length > 0) {
+      entries = [...entries].sort((left, right) =>
+        compareQueryEntries(left, right, this.state.orderBy),
+      );
+    }
+
+    if (this.state.startAfter.length > 0) {
+      const startAfterIndex = entries.findIndex((entry) =>
+        queryEntryMatchesCursorValues(entry, this.state.orderBy, this.state.startAfter),
+      );
+
+      entries = startAfterIndex === -1 ? [] : entries.slice(startAfterIndex + 1);
+    }
+
+    if (this.state.limit !== null) {
+      entries = entries.slice(0, this.state.limit);
+    }
+
+    const docs = entries.map(([id, record]) => ({
+      exists: true,
+      id,
+      data: () => structuredClone(record),
+    }));
 
     return { docs };
   }
 }
 
 class FakeFirestoreCollection extends FakeFirestoreQuery {
-  constructor(store: Map<string, FakeFirestoreRecord>) {
-    super(store);
+  constructor(
+    store: Map<string, FakeFirestoreRecord>,
+    instrumentation: FakeFirestoreInstrumentation,
+  ) {
+    super(store, instrumentation);
   }
 
   doc(id: string = crypto.randomUUID()) {
-    return new FakeFirestoreDocumentReference(this.store, id);
+    return new FakeFirestoreDocumentReference(this.store, this.instrumentation, id);
   }
 }
 
@@ -157,9 +239,20 @@ class FakeFirestoreTransaction {
 
 class FakeFirestoreDatabase {
   private readonly stores = new Map<string, Map<string, FakeFirestoreRecord>>();
+  readonly instrumentation: FakeFirestoreInstrumentation = {
+    documentGetCalls: [],
+    getAllCalls: [],
+    queryReads: [],
+  };
 
   collection(path: string) {
-    return new FakeFirestoreCollection(this.getStore(path));
+    return new FakeFirestoreCollection(this.getStore(path), this.instrumentation);
+  }
+
+  async getAll(...refs: unknown[]) {
+    const resolvedRefs = refs.map((ref) => getFakeRef(ref));
+    this.instrumentation.getAllCalls.push(resolvedRefs.map((ref) => ref.id));
+    return resolvedRefs.map((ref) => ref.readSnapshot());
   }
 
   async runTransaction<T>(updateFunction: (transaction: FakeFirestoreTransaction) => Promise<T>) {
@@ -249,13 +342,135 @@ function compareUnknown(left: unknown, right: unknown): number {
   return String(left).localeCompare(String(right));
 }
 
-describe("firestoreEngine unique constraints", () => {
-  function createEngine(database: FakeFirestoreDatabase = new FakeFirestoreDatabase()) {
-    return firestoreEngine({
-      database: database as unknown as Parameters<typeof firestoreEngine>[0]["database"],
-    });
+function createEngine(database: FakeFirestoreDatabase = new FakeFirestoreDatabase()) {
+  return firestoreEngine({
+    database: database as unknown as Parameters<typeof firestoreEngine>[0]["database"],
+  });
+}
+
+function compareQueryEntries(
+  left: readonly [string, FakeFirestoreRecord],
+  right: readonly [string, FakeFirestoreRecord],
+  orderBy: readonly FakeOrderByClause[],
+): number {
+  for (const clause of orderBy) {
+    const leftValue = readFieldValue(left[1], clause.fieldPath);
+    const rightValue = readFieldValue(right[1], clause.fieldPath);
+    const base = compareUnknown(leftValue, rightValue);
+
+    if (base !== 0) {
+      return clause.direction === "desc" ? -base : base;
+    }
   }
 
+  return left[0].localeCompare(right[0]);
+}
+
+function queryEntryMatchesCursorValues(
+  entry: readonly [string, FakeFirestoreRecord],
+  orderBy: readonly FakeOrderByClause[],
+  cursorValues: readonly unknown[],
+): boolean {
+  if (cursorValues.length !== orderBy.length) {
+    return false;
+  }
+
+  return orderBy.every(
+    (clause, index) => readFieldValue(entry[1], clause.fieldPath) === cursorValues[index],
+  );
+}
+
+describe("firestoreEngine query execution", () => {
+  test("batchGet uses getAll to read unique keys and preserves request order", async () => {
+    const database = new FakeFirestoreDatabase();
+    const engine = createEngine(database);
+
+    await engine.batchSet("users", [
+      { key: "u1", doc: { id: "u1", name: "A" }, indexes: { primary: "u1" } },
+      { key: "u2", doc: { id: "u2", name: "B" }, indexes: { primary: "u2" } },
+    ]);
+
+    const results = await engine.batchGet("users", ["u2", "u1", "u2", "missing"]);
+
+    expect(results.map((entry) => entry.key)).toEqual(["u2", "u1", "u2"]);
+    expect(database.instrumentation.getAllCalls).toEqual([
+      ["doc:users:u2", "doc:users:u1", "doc:users:missing"],
+    ]);
+    expect(database.instrumentation.documentGetCalls).toEqual([]);
+  });
+
+  test("query pushes sorted pagination into Firestore when the query is expressible", async () => {
+    const database = new FakeFirestoreDatabase();
+    const engine = createEngine(database);
+
+    await engine.batchSet("users", [
+      {
+        key: "u1",
+        doc: { id: "u1", createdAt: "2025-01-01" },
+        indexes: { byCreatedAt: "2025-01-01" },
+      },
+      {
+        key: "u2",
+        doc: { id: "u2", createdAt: "2025-02-01" },
+        indexes: { byCreatedAt: "2025-02-01" },
+      },
+      {
+        key: "u3",
+        doc: { id: "u3", createdAt: "2025-03-01" },
+        indexes: { byCreatedAt: "2025-03-01" },
+      },
+    ]);
+
+    const firstPage = await engine.query("users", {
+      index: "byCreatedAt",
+      filter: { value: { $begins: "2025-" } },
+      sort: "desc",
+      limit: 2,
+    });
+
+    expect(firstPage.documents.map((entry) => entry.key)).toEqual(["u3", "u2"]);
+    expect(database.instrumentation.queryReads.at(-1)).toEqual({
+      filters: [
+        { fieldPath: "collection", opStr: "==", value: "users" },
+        { fieldPath: "indexes.byCreatedAt", opStr: ">=", value: "2025-" },
+        { fieldPath: "indexes.byCreatedAt", opStr: "<=", value: "2025-\uf8ff" },
+      ],
+      orderBy: [
+        { fieldPath: "indexes.byCreatedAt", direction: "desc" },
+        { fieldPath: "createdAt", direction: "asc" },
+        { fieldPath: "key", direction: "asc" },
+      ],
+      startAfter: [],
+      limit: 3,
+    });
+
+    const secondPage = await engine.query("users", {
+      index: "byCreatedAt",
+      filter: { value: { $begins: "2025-" } },
+      sort: "desc",
+      limit: 2,
+      cursor: firstPage.cursor ?? undefined,
+    });
+
+    expect(secondPage.documents.map((entry) => entry.key)).toEqual(["u1"]);
+    expect(database.instrumentation.queryReads.at(-1)).toEqual({
+      filters: [
+        { fieldPath: "collection", opStr: "==", value: "users" },
+        { fieldPath: "indexes.byCreatedAt", opStr: ">=", value: "2025-" },
+        { fieldPath: "indexes.byCreatedAt", opStr: "<=", value: "2025-\uf8ff" },
+      ],
+      orderBy: [
+        { fieldPath: "indexes.byCreatedAt", direction: "desc" },
+        { fieldPath: "createdAt", direction: "asc" },
+        { fieldPath: "key", direction: "asc" },
+      ],
+      startAfter: ["2025-02-01", 2, "u2"],
+      limit: 3,
+    });
+  });
+});
+
+describe("firestoreEngine unique constraints", () => {
   test("create rejects duplicate unique index ownership", async () => {
     const engine = createEngine();
 

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -269,6 +269,8 @@ interface FakeFirestoreDocSnapshot {
 }
 
 class FakeFirestoreQuery {
+  private shouldThrowOnGet = false;
+
   constructor(
     protected readonly docs: AnyRecord[],
     protected readonly whereCalls: Array<{ field: string; op: string; value: unknown }>,
@@ -307,12 +309,30 @@ class FakeFirestoreQuery {
     return new FakeFirestoreQuery(filtered, this.whereCalls, this.onGet);
   }
 
+  orderBy(_fieldPath: string, _directionStr?: "asc" | "desc") {
+    this.shouldThrowOnGet = true;
+    return this;
+  }
+
+  startAfter(..._fieldValues: unknown[]) {
+    return this;
+  }
+
   limit(_limit: number) {
     return this;
   }
 
   async get() {
     this.onGet();
+
+    if (this.shouldThrowOnGet) {
+      const error = new Error("FAILED_PRECONDITION: The query requires an index") as Error & {
+        name: string;
+      };
+      error.name = "FAILED_PRECONDITION";
+      throw error;
+    }
+
     const snapshots: FakeFirestoreDocSnapshot[] = this.docs.map((doc) => ({
       exists: true,
       id: String(doc.key),
@@ -996,6 +1016,27 @@ describe("non-SQL query pushdown", () => {
       }),
     ).rejects.toThrow(/cursor/i);
     expect(db.documentGetCalls).toBe(0);
+  });
+
+  test("firestore query falls back when native pushdown requires an index", async () => {
+    const db = new FakeFirestoreDatabase([
+      makeEngineDoc("u1", 1, { byEmail: "a@example.com" }, { id: "u1" }),
+      makeEngineDoc("u2", 2, { byEmail: "b@example.com" }, { id: "u2" }),
+      makeEngineDoc("u3", 3, { byEmail: "a@example.com" }, { id: "u3" }),
+    ]);
+    const engine = firestoreEngine({
+      database: db as unknown as Parameters<typeof firestoreEngine>[0]["database"],
+    });
+
+    const result = await engine.query("users", {
+      index: "byEmail",
+      filter: { value: "a@example.com" },
+      limit: 2,
+    });
+
+    expect(result.documents.map((doc) => doc.key)).toEqual(["u1", "u3"]);
+    expect(result.cursor).toBeNull();
+    expect(db.documentGetCalls).toBe(2);
   });
 
   test("dynamodb query uses a secondary lookup item query instead of FilterExpression scans", async () => {


### PR DESCRIPTION
## Summary
- push expressible Firestore queries into backend `orderBy`/`startAfter`/`limit` execution for sorted pagination and scan/equality pagination
- batch Firestore `batchGet` and `batchGetWithMetadata` reads through `getAll` while preserving request order and duplicate semantics
- keep the existing local fallback path for query shapes Firestore cannot represent safely, and add regression coverage plus a changeset

## Why
Issue #119 calls out two remaining Firestore adapter bottlenecks:
- indexed queries were still materializing matched records and then sorting/paginating client-side
- batched key reads still performed one document fetch per key

This change pushes both paths down into Firestore where the query shape is expressible, while preserving the current fallback behavior for unsupported shapes.

## Developer Impact
- Firestore indexed queries can now page from opaque cursors without reading the full matched set when the adapter can map the query directly to Firestore primitives
- multi-key Firestore reads now use a single batched fetch path when `getAll` is available
- the adapter still falls back to local matching/order logic for shapes that would otherwise change semantics

## Root Cause
The Firestore engine was using server-side filtering only for the initial candidate set. Ordering, cursor pagination, and multi-key fetches were still handled in client code, which left latency and memory usage proportional to the full result set.

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun run typecheck`
- `bun test ./tests/unit/firestore-engine.test.ts ./tests/unit/non-sql-query-pushdown.test.ts`

## Notes
- Firestore emulator integration validation could not be run in this environment because Docker was unavailable (`Cannot connect to the Docker daemon at unix:///Users/samuellaycock/.orbstack/run/docker.sock`).

Closes #119