### PR TITLE
feat(mongodb): add queryIndexes option to provision compound native indexes

### DIFF
--- a/.changeset/mongodb-query-index-provisioning.md
+++ b/.changeset/mongodb-query-index-provisioning.md
@@ -1,0 +1,9 @@
+---
+"nosql-odm": minor
+---
+
+Add `queryIndexes` option to `mongoDbEngine` to provision compound MongoDB
+indexes for named index fields used by native query plans. When provided, two
+compound indexes are created per name — ascending and descending on
+`indexes.<name>` — so that sorted, paginated, and filtered queries can use an
+efficient index plan rather than relying on a collection scan.

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -107,6 +107,15 @@ export interface MongoDbEngineOptions {
    * fallback path.
    */
   onQueryFallbackScan?: (event: MongoDbQueryFallbackScanEvent) => void;
+  /**
+   * Index names to provision compound MongoDB indexes for. For each name, two
+   * compound indexes are created on the documents collection:
+   *   { collection, indexes.<name>, createdAt, key } ascending
+   *   { collection, indexes.<name>, createdAt, key } descending on indexes.<name>
+   * These indexes back the native query plans produced by sorted and paginated
+   * queries that filter on the named index field.
+   */
+  queryIndexes?: string[];
 }
 
 export interface MongoDbQueryEngine extends QueryEngine<never> {}
@@ -174,7 +183,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
     options.metadataCollection ?? DEFAULT_METADATA_COLLECTION,
   );
 
-  const ready = ensureSchema(documentsCollection, metadataCollection);
+  const ready = ensureSchema(documentsCollection, metadataCollection, options.queryIndexes ?? []);
 
   const engine: MongoDbQueryEngine = {
     capabilities: {
@@ -910,6 +919,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
 async function ensureSchema(
   documentsCollection: MongoCollectionLike,
   metadataCollection: MongoCollectionLike,
+  queryIndexes: string[],
 ): Promise<void> {
   await documentsCollection.createIndex(
     {
@@ -960,6 +970,24 @@ async function ensureSchema(
       unique: true,
     },
   );
+
+  for (const name of queryIndexes) {
+    const indexField = `indexes.${name}` as const;
+
+    await documentsCollection.createIndex({
+      collection: 1,
+      [indexField]: 1,
+      createdAt: 1,
+      key: 1,
+    });
+
+    await documentsCollection.createIndex({
+      collection: 1,
+      [indexField]: -1,
+      createdAt: 1,
+      key: 1,
+    });
+  }
 }
 
 async function nextCreatedAt(

--- a/tests/unit/mongodb-engine-query-indexes.test.ts
+++ b/tests/unit/mongodb-engine-query-indexes.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+
+import { mongoDbEngine } from "../../src/engines/mongodb";
+
+type AnyRecord = Record<string, unknown>;
+
+class FakeMongoCollection {
+  readonly createIndexCalls: Array<{ keys: Record<string, 1 | -1>; options?: AnyRecord }> = [];
+
+  async createIndex(keys: Record<string, 1 | -1>, options?: AnyRecord) {
+    this.createIndexCalls.push({ keys, options });
+    return "ok";
+  }
+
+  find(_filter: AnyRecord) {
+    return {
+      sort(_sort: AnyRecord) {
+        return this;
+      },
+      limit(_value: number) {
+        return this;
+      },
+      async toArray(): Promise<unknown[]> {
+        return [];
+      },
+    };
+  }
+
+  async findOne(_filter: AnyRecord) {
+    return null;
+  }
+
+  async insertOne(_document: AnyRecord) {
+    return { acknowledged: true };
+  }
+
+  async updateOne(_filter: AnyRecord, _update: AnyRecord, _options?: AnyRecord) {
+    return { matchedCount: 1 };
+  }
+
+  async deleteOne(_filter: AnyRecord) {
+    return { acknowledged: true };
+  }
+
+  async bulkWrite(_operations: AnyRecord[], _options?: AnyRecord) {
+    return { matchedCount: 0 };
+  }
+
+  async findOneAndUpdate(_filter: AnyRecord, update: AnyRecord, _options?: AnyRecord) {
+    const inc = (update as { $inc?: { value?: number } }).$inc?.value ?? 0;
+    return { kind: "sequence", value: inc };
+  }
+}
+
+class FakeMongoDatabase {
+  readonly documents = new FakeMongoCollection();
+  readonly metadata = new FakeMongoCollection();
+
+  collection(name: string) {
+    if (name === "nosql_odm_documents") {
+      return this.documents;
+    }
+
+    if (name === "nosql_odm_metadata") {
+      return this.metadata;
+    }
+
+    throw new Error(`Unexpected collection: ${name}`);
+  }
+}
+
+describe("mongodb engine query index provisioning", () => {
+  test("creates no query indexes when queryIndexes is not provided", async () => {
+    const db = new FakeMongoDatabase();
+    const engine = mongoDbEngine({ database: db });
+
+    await engine.get("users", "u1");
+
+    const queryIndexCalls = db.documents.createIndexCalls.filter(
+      (call) =>
+        "indexes" in call.keys || Object.keys(call.keys).some((k) => k.startsWith("indexes.")),
+    );
+
+    expect(queryIndexCalls).toHaveLength(0);
+  });
+
+  test("creates no query indexes when queryIndexes is an empty array", async () => {
+    const db = new FakeMongoDatabase();
+    const engine = mongoDbEngine({ database: db, queryIndexes: [] });
+
+    await engine.get("users", "u1");
+
+    const queryIndexCalls = db.documents.createIndexCalls.filter(({ keys }) =>
+      Object.keys(keys).some((k) => k.startsWith("indexes.")),
+    );
+
+    expect(queryIndexCalls).toHaveLength(0);
+  });
+
+  test("creates ascending and descending compound indexes for a single query index", async () => {
+    const db = new FakeMongoDatabase();
+    const engine = mongoDbEngine({ database: db, queryIndexes: ["byEmail"] });
+
+    await engine.get("users", "u1");
+
+    const queryIndexCalls = db.documents.createIndexCalls.filter(({ keys }) =>
+      Object.keys(keys).some((k) => k.startsWith("indexes.")),
+    );
+
+    expect(queryIndexCalls).toHaveLength(2);
+    expect(queryIndexCalls).toContainEqual({
+      keys: { collection: 1, "indexes.byEmail": 1, createdAt: 1, key: 1 },
+      options: undefined,
+    });
+    expect(queryIndexCalls).toContainEqual({
+      keys: { collection: 1, "indexes.byEmail": -1, createdAt: 1, key: 1 },
+      options: undefined,
+    });
+  });
+
+  test("creates ascending and descending compound indexes for multiple query indexes", async () => {
+    const db = new FakeMongoDatabase();
+    const engine = mongoDbEngine({
+      database: db,
+      queryIndexes: ["byEmail", "byStatus", "byCreatedAt"],
+    });
+
+    await engine.get("users", "u1");
+
+    const queryIndexCalls = db.documents.createIndexCalls.filter(({ keys }) =>
+      Object.keys(keys).some((k) => k.startsWith("indexes.")),
+    );
+
+    expect(queryIndexCalls).toHaveLength(6);
+
+    for (const name of ["byEmail", "byStatus", "byCreatedAt"]) {
+      expect(queryIndexCalls).toContainEqual({
+        keys: { collection: 1, [`indexes.${name}`]: 1, createdAt: 1, key: 1 },
+        options: undefined,
+      });
+      expect(queryIndexCalls).toContainEqual({
+        keys: { collection: 1, [`indexes.${name}`]: -1, createdAt: 1, key: 1 },
+        options: undefined,
+      });
+    }
+  });
+
+  test("query index provisioning completes before the first operation resolves", async () => {
+    const db = new FakeMongoDatabase();
+    const engine = mongoDbEngine({ database: db, queryIndexes: ["byEmail"] });
+
+    await engine.get("users", "u1");
+
+    const queryIndexCalls = db.documents.createIndexCalls.filter(({ keys }) =>
+      Object.keys(keys).some((k) => k.startsWith("indexes.")),
+    );
+
+    expect(queryIndexCalls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `queryIndexes?: string[]` option to `MongoDbEngineOptions`
- When provided, `ensureSchema` creates two compound MongoDB indexes per named index field: one ascending and one descending on `indexes.<name>`, backed by `{ collection, createdAt, key }` suffixes
- The ascending index covers unsorted filtered queries and ascending sorted queries; the descending index covers descending sorted queries
- No indexes are created when `queryIndexes` is omitted or empty — fully backwards-compatible

## Problem

`ensureSchema()` created metadata indexes but not compound indexes for the `indexes.<name>` query patterns used by `resolveMongoNativeQueryPlan()`. The adapter could report a native plan while MongoDB still executed it poorly against an unindexed field. Users had no way to provision these indexes without knowing the internal document schema.

## Compound index shape

For each index name in `queryIndexes`:
```
{ collection: 1, "indexes.<name>": 1, createdAt: 1, key: 1 }
{ collection: 1, "indexes.<name>": -1, createdAt: 1, key: 1 }
```

## Test plan

- [x] Unit tests covering: no indexes when option is omitted, no indexes on empty array, ascending + descending indexes per name for single and multiple names, provisioning completes before first operation resolves
- [x] All 565 existing unit tests pass
- [x] `bun typecheck` passes
- [x] `bun fmt` and `bun lint:fix` applied

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)