### PR TITLE
[codex] Add IndexedDB query index entries

### DIFF
--- a/.changeset/indexeddb-query-index-entries.md
+++ b/.changeset/indexeddb-query-index-entries.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": minor
+---
+
+Add IndexedDB-backed query index entries so indexed queries can resolve matching document keys without loading the full collection document store.

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -106,6 +106,7 @@ const STORE_QUERY_INDEX_ENTRIES = "query_index_entries";
 const QUERY_INDEX_LOOKUP = "lookup";
 
 const META_SEQUENCE_KEY = "sequence";
+const META_QUERY_INDEX_BACKFILL_KEY = "queryIndexEntriesBackfilled";
 const OUTDATED_PAGE_LIMIT = 100;
 
 interface StoredDocumentRecord {
@@ -127,7 +128,7 @@ interface QueryIndexEntryRecord {
 }
 
 interface MetaSequenceRecord {
-  key: typeof META_SEQUENCE_KEY;
+  key: typeof META_SEQUENCE_KEY | typeof META_QUERY_INDEX_BACKFILL_KEY;
   value: number;
 }
 
@@ -685,6 +686,12 @@ async function listCollectionDocumentsByIndex(
     return null;
   }
 
+  const equalityValue = resolveEqualityFilterValue(params.filter.value);
+
+  if (equalityValue === null) {
+    return null;
+  }
+
   return withTransaction(
     db,
     [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
@@ -696,7 +703,7 @@ async function listCollectionDocumentsByIndex(
         indexEntriesStore,
         collection,
         params.index!,
-        params.filter!.value,
+        equalityValue,
       );
       const records: StoredDocumentRecord[] = [];
 
@@ -727,17 +734,11 @@ async function loadMatchingIndexEntries(
   indexEntriesStore: IndexedDbObjectStoreLike,
   collection: string,
   indexName: string,
-  filter: string | number | FieldCondition,
+  equalityValue: string,
 ): Promise<QueryIndexEntryRecord[]> {
-  const equalityValue = resolveEqualityFilterValue(filter);
-  const rawEntries =
-    equalityValue === null
-      ? await requestToPromise(indexEntriesStore.getAll())
-      : await requestToPromise(
-          indexEntriesStore
-            .index(QUERY_INDEX_LOOKUP)
-            .getAll([collection, indexName, equalityValue]),
-        );
+  const rawEntries = await requestToPromise(
+    indexEntriesStore.index(QUERY_INDEX_LOOKUP).getAll([collection, indexName, equalityValue]),
+  );
 
   return rawEntries
     .map((entry) => parseQueryIndexEntryRecord(entry))
@@ -745,7 +746,7 @@ async function loadMatchingIndexEntries(
       (entry) =>
         entry.collection === collection &&
         entry.indexName === indexName &&
-        matchesFilter(entry.indexValue, filter),
+        entry.indexValue === equalityValue,
     );
 }
 
@@ -1247,13 +1248,15 @@ function requestToPromise<T>(request: IndexedDbRequestLike<T>): Promise<T> {
 async function ensureQueryIndexEntriesBackfilled(db: IndexedDbDatabaseLike): Promise<void> {
   await withTransaction(
     db,
-    [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+    [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES, STORE_META],
     "readwrite",
     async (tx) => {
       const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
-      const existingEntries = await requestToPromise(indexStore.getAll());
+      const metaStore = tx.objectStore(STORE_META);
+      const backfilledRaw = await requestToPromise(metaStore.get(META_QUERY_INDEX_BACKFILL_KEY));
 
-      if (existingEntries.length > 0) {
+      if (backfilledRaw !== undefined) {
+        parseMetaFlagRecord(backfilledRaw, META_QUERY_INDEX_BACKFILL_KEY);
         return;
       }
 
@@ -1269,6 +1272,8 @@ async function ensureQueryIndexEntriesBackfilled(db: IndexedDbDatabaseLike): Pro
           record.indexes,
         );
       }
+
+      await saveMetaFlag(metaStore, META_QUERY_INDEX_BACKFILL_KEY);
     },
   );
 }
@@ -1463,6 +1468,30 @@ async function loadSequence(metaStore: IndexedDbObjectStoreLike): Promise<number
 
 async function saveSequence(metaStore: IndexedDbObjectStoreLike, value: number): Promise<void> {
   const record: MetaSequenceRecord = { key: META_SEQUENCE_KEY, value };
+  await requestToPromise(metaStore.put(record));
+}
+
+function parseMetaFlagRecord(
+  value: unknown,
+  expectedKey: typeof META_QUERY_INDEX_BACKFILL_KEY,
+): void {
+  if (!isRecord(value)) {
+    throw new Error("IndexedDB meta store contains an invalid flag record");
+  }
+
+  const key = value.key;
+  const flagValue = value.value;
+
+  if (key !== expectedKey || flagValue !== 1) {
+    throw new Error("IndexedDB meta store contains an invalid flag record");
+  }
+}
+
+async function saveMetaFlag(
+  metaStore: IndexedDbObjectStoreLike,
+  key: typeof META_QUERY_INDEX_BACKFILL_KEY,
+): Promise<void> {
+  const record: MetaSequenceRecord = { key, value: 1 };
   await requestToPromise(metaStore.put(record));
 }
 

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -57,9 +57,15 @@ interface IndexedDbOpenRequestLike<TDatabase> extends IndexedDbRequestLike<TData
 
 interface IndexedDbObjectStoreLike {
   get(key: string): IndexedDbRequestLike<unknown>;
-  getAll(): IndexedDbRequestLike<unknown[]>;
+  getAll(query?: unknown): IndexedDbRequestLike<unknown[]>;
   put(value: unknown): IndexedDbRequestLike<unknown>;
   delete(key: string): IndexedDbRequestLike<unknown>;
+  index(name: string): IndexedDbIndexLike;
+  createIndex(name: string, keyPath: string | string[]): unknown;
+}
+
+interface IndexedDbIndexLike {
+  getAll(query?: unknown): IndexedDbRequestLike<unknown[]>;
 }
 
 interface IndexedDbTransactionLike {
@@ -89,12 +95,15 @@ interface IndexedDbFactoryLike {
 // Storage model
 // ---------------------------------------------------------------------------
 
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 const STORE_DOCUMENTS = "documents";
 const STORE_META = "meta";
 const STORE_MIGRATION_LOCKS = "migration_locks";
 const STORE_MIGRATION_CHECKPOINTS = "migration_checkpoints";
+const STORE_QUERY_INDEX_ENTRIES = "query_index_entries";
+
+const QUERY_INDEX_LOOKUP = "lookup";
 
 const META_SEQUENCE_KEY = "sequence";
 const OUTDATED_PAGE_LIMIT = 100;
@@ -107,6 +116,14 @@ interface StoredDocumentRecord {
   doc: Record<string, unknown>;
   indexes: ResolvedIndexKeys;
   uniqueIndexes: ResolvedIndexKeys;
+}
+
+interface QueryIndexEntryRecord {
+  id: string;
+  collection: string;
+  indexName: string;
+  indexValue: string;
+  key: string;
 }
 
 interface MetaSequenceRecord {
@@ -174,122 +191,161 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       const db = await dbPromise;
       const docId = makeDocumentId(collection, key);
 
-      await withTransaction(db, [STORE_DOCUMENTS, STORE_META], "readwrite", async (tx) => {
-        const docsStore = tx.objectStore(STORE_DOCUMENTS);
-        const metaStore = tx.objectStore(STORE_META);
-        const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const metaStore = tx.objectStore(STORE_META);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+          const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
 
-        const existing = await requestToPromise(docsStore.get(docId));
+          const existing = await requestToPromise(docsStore.get(docId));
 
-        if (existing !== undefined) {
-          throw new EngineDocumentAlreadyExistsError(collection, key);
-        }
+          if (existing !== undefined) {
+            throw new EngineDocumentAlreadyExistsError(collection, key);
+          }
 
-        assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
+          assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
 
-        const sequence = (await loadSequence(metaStore)) + 1;
+          const sequence = (await loadSequence(metaStore)) + 1;
 
-        await requestToPromise(
-          docsStore.put(
-            createStoredDocumentRecord({
-              id: docId,
-              collection,
-              key,
-              createdAt: sequence,
-              doc,
-              indexes,
-              uniqueIndexes,
-            }),
-          ),
-        );
+          const record = createStoredDocumentRecord({
+            id: docId,
+            collection,
+            key,
+            createdAt: sequence,
+            doc,
+            indexes,
+            uniqueIndexes,
+          });
 
-        await saveSequence(metaStore, sequence);
-      });
+          await requestToPromise(docsStore.put(record));
+          await replaceQueryIndexEntries(indexStore, collection, key, {}, indexes);
+
+          await saveSequence(metaStore, sequence);
+        },
+      );
     },
 
     async put(collection, key, doc, indexes, _options, _migrationMetadata, uniqueIndexes) {
       const db = await dbPromise;
       const docId = makeDocumentId(collection, key);
 
-      await withTransaction(db, [STORE_DOCUMENTS, STORE_META], "readwrite", async (tx) => {
-        const docsStore = tx.objectStore(STORE_DOCUMENTS);
-        const metaStore = tx.objectStore(STORE_META);
-        const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const metaStore = tx.objectStore(STORE_META);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+          const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
 
-        const existingRaw = await requestToPromise(docsStore.get(docId));
+          const existingRaw = await requestToPromise(docsStore.get(docId));
 
-        let createdAt: number;
+          let createdAt: number;
+          let existingIndexes: ResolvedIndexKeys = {};
 
-        if (existingRaw === undefined) {
-          createdAt = (await loadSequence(metaStore)) + 1;
-          await saveSequence(metaStore, createdAt);
-        } else {
-          createdAt = parseStoredDocumentRecord(existingRaw).createdAt;
-        }
+          if (existingRaw === undefined) {
+            createdAt = (await loadSequence(metaStore)) + 1;
+            await saveSequence(metaStore, createdAt);
+          } else {
+            const existing = parseStoredDocumentRecord(existingRaw);
+            createdAt = existing.createdAt;
+            existingIndexes = existing.indexes;
+          }
 
-        assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
+          assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
 
-        await requestToPromise(
-          docsStore.put(
-            createStoredDocumentRecord({
-              id: docId,
-              collection,
-              key,
-              createdAt,
-              doc,
-              indexes,
-              uniqueIndexes,
-            }),
-          ),
-        );
-      });
+          const record = createStoredDocumentRecord({
+            id: docId,
+            collection,
+            key,
+            createdAt,
+            doc,
+            indexes,
+            uniqueIndexes,
+          });
+
+          await requestToPromise(docsStore.put(record));
+          await replaceQueryIndexEntries(indexStore, collection, key, existingIndexes, indexes);
+        },
+      );
     },
 
     async update(collection, key, doc, indexes, _options, _migrationMetadata, uniqueIndexes) {
       const db = await dbPromise;
       const docId = makeDocumentId(collection, key);
 
-      await withTransaction(db, [STORE_DOCUMENTS], "readwrite", async (tx) => {
-        const docsStore = tx.objectStore(STORE_DOCUMENTS);
-        const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
-        const existingRaw = await requestToPromise(docsStore.get(docId));
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+          const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
+          const existingRaw = await requestToPromise(docsStore.get(docId));
 
-        if (existingRaw === undefined) {
-          throw new EngineDocumentNotFoundError(collection, key);
-        }
+          if (existingRaw === undefined) {
+            throw new EngineDocumentNotFoundError(collection, key);
+          }
 
-        const existing = parseStoredDocumentRecord(existingRaw);
+          const existing = parseStoredDocumentRecord(existingRaw);
 
-        assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
+          assertUniqueIndexes(collection, key, uniqueIndexes ?? {}, collectionRecords);
 
-        await requestToPromise(
-          docsStore.put(
-            createStoredDocumentRecord({
-              id: docId,
-              collection,
-              key,
-              createdAt: existing.createdAt,
-              doc,
-              indexes,
-              uniqueIndexes,
-            }),
-          ),
-        );
-      });
+          const record = createStoredDocumentRecord({
+            id: docId,
+            collection,
+            key,
+            createdAt: existing.createdAt,
+            doc,
+            indexes,
+            uniqueIndexes,
+          });
+
+          await requestToPromise(docsStore.put(record));
+          await replaceQueryIndexEntries(indexStore, collection, key, existing.indexes, indexes);
+        },
+      );
     },
 
     async delete(collection, key) {
       const db = await dbPromise;
       const docId = makeDocumentId(collection, key);
 
-      await withTransaction(db, [STORE_DOCUMENTS], "readwrite", async (tx) => {
-        await requestToPromise(tx.objectStore(STORE_DOCUMENTS).delete(docId));
-      });
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const existingRaw = await requestToPromise(docsStore.get(docId));
+
+          if (existingRaw !== undefined) {
+            const existing = parseStoredDocumentRecord(existingRaw);
+            await replaceQueryIndexEntries(
+              tx.objectStore(STORE_QUERY_INDEX_ENTRIES),
+              collection,
+              key,
+              existing.indexes,
+              {},
+            );
+          }
+
+          await requestToPromise(docsStore.delete(docId));
+        },
+      );
     },
 
     async query(collection, params) {
       const db = await dbPromise;
-      const records = await listCollectionDocuments(db, collection);
+      const records =
+        (await listCollectionDocumentsByIndex(db, collection, params)) ??
+        (await listCollectionDocuments(db, collection));
       const matched = matchDocuments(records, params);
 
       return paginateQuery(collection, matched, params);
@@ -320,65 +376,96 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
     async batchSet(collection, items) {
       const db = await dbPromise;
 
-      await withTransaction(db, [STORE_DOCUMENTS, STORE_META], "readwrite", async (tx) => {
-        const docsStore = tx.objectStore(STORE_DOCUMENTS);
-        const metaStore = tx.objectStore(STORE_META);
-        const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
-        const recordsByKey = new Map(
-          collectionRecords.map((record) => [record.key, record] as const),
-        );
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const metaStore = tx.objectStore(STORE_META);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+          const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
+          const recordsByKey = new Map(
+            collectionRecords.map((record) => [record.key, record] as const),
+          );
 
-        let sequence = await loadSequence(metaStore);
-        let sequenceChanged = false;
+          let sequence = await loadSequence(metaStore);
+          let sequenceChanged = false;
 
-        for (const item of items) {
-          const docId = makeDocumentId(collection, item.key);
-          const existingRaw = await requestToPromise(docsStore.get(docId));
+          for (const item of items) {
+            const docId = makeDocumentId(collection, item.key);
+            const existingRaw = await requestToPromise(docsStore.get(docId));
 
-          let createdAt: number;
+            let createdAt: number;
+            let existingIndexes: ResolvedIndexKeys = {};
 
-          if (existingRaw === undefined) {
-            sequence += 1;
-            sequenceChanged = true;
-            createdAt = sequence;
-          } else {
-            createdAt = parseStoredDocumentRecord(existingRaw).createdAt;
+            if (existingRaw === undefined) {
+              sequence += 1;
+              sequenceChanged = true;
+              createdAt = sequence;
+            } else {
+              const existing = parseStoredDocumentRecord(existingRaw);
+              createdAt = existing.createdAt;
+              existingIndexes = existing.indexes;
+            }
+
+            const uniqueIndexes = item.uniqueIndexes ?? {};
+
+            assertUniqueIndexes(collection, item.key, uniqueIndexes, [...recordsByKey.values()]);
+
+            const storedRecord = createStoredDocumentRecord({
+              id: docId,
+              collection,
+              key: item.key,
+              createdAt,
+              doc: item.doc,
+              indexes: item.indexes,
+              uniqueIndexes,
+            });
+
+            await requestToPromise(docsStore.put(storedRecord));
+            await replaceQueryIndexEntries(
+              indexStore,
+              collection,
+              item.key,
+              existingIndexes,
+              item.indexes,
+            );
+            recordsByKey.set(item.key, storedRecord);
           }
 
-          const uniqueIndexes = item.uniqueIndexes ?? {};
-
-          assertUniqueIndexes(collection, item.key, uniqueIndexes, [...recordsByKey.values()]);
-
-          const storedRecord = createStoredDocumentRecord({
-            id: docId,
-            collection,
-            key: item.key,
-            createdAt,
-            doc: item.doc,
-            indexes: item.indexes,
-            uniqueIndexes,
-          });
-
-          await requestToPromise(docsStore.put(storedRecord));
-          recordsByKey.set(item.key, storedRecord);
-        }
-
-        if (sequenceChanged) {
-          await saveSequence(metaStore, sequence);
-        }
-      });
+          if (sequenceChanged) {
+            await saveSequence(metaStore, sequence);
+          }
+        },
+      );
     },
 
     async batchDelete(collection, keys) {
       const db = await dbPromise;
 
-      await withTransaction(db, [STORE_DOCUMENTS], "readwrite", async (tx) => {
-        const docsStore = tx.objectStore(STORE_DOCUMENTS);
+      await withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
 
-        for (const key of keys) {
-          await requestToPromise(docsStore.delete(makeDocumentId(collection, key)));
-        }
-      });
+          for (const key of keys) {
+            const existingRaw = await requestToPromise(
+              docsStore.get(makeDocumentId(collection, key)),
+            );
+
+            if (existingRaw !== undefined) {
+              const existing = parseStoredDocumentRecord(existingRaw);
+              await replaceQueryIndexEntries(indexStore, collection, key, existing.indexes, {});
+            }
+
+            await requestToPromise(docsStore.delete(makeDocumentId(collection, key)));
+          }
+        },
+      );
     },
 
     migration: {
@@ -587,6 +674,105 @@ async function loadCollectionRecordsFromStore(
   });
 
   return records;
+}
+
+async function listCollectionDocumentsByIndex(
+  db: IndexedDbDatabaseLike,
+  collection: string,
+  params: QueryParams,
+): Promise<StoredDocumentRecord[] | null> {
+  if (!params.index || !params.filter) {
+    return null;
+  }
+
+  return withTransaction(
+    db,
+    [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+    "readonly",
+    async (tx) => {
+      const indexEntriesStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+      const docsStore = tx.objectStore(STORE_DOCUMENTS);
+      const entries = await loadMatchingIndexEntries(
+        indexEntriesStore,
+        collection,
+        params.index!,
+        params.filter!.value,
+      );
+      const records: StoredDocumentRecord[] = [];
+
+      for (const entry of entries) {
+        const raw = await requestToPromise(docsStore.get(makeDocumentId(collection, entry.key)));
+
+        if (raw === undefined) {
+          continue;
+        }
+
+        records.push(parseStoredDocumentRecord(raw));
+      }
+
+      records.sort((a, b) => {
+        if (a.createdAt !== b.createdAt) {
+          return a.createdAt - b.createdAt;
+        }
+
+        return a.key.localeCompare(b.key);
+      });
+
+      return records;
+    },
+  );
+}
+
+async function loadMatchingIndexEntries(
+  indexEntriesStore: IndexedDbObjectStoreLike,
+  collection: string,
+  indexName: string,
+  filter: string | number | FieldCondition,
+): Promise<QueryIndexEntryRecord[]> {
+  const equalityValue = resolveEqualityFilterValue(filter);
+  const rawEntries =
+    equalityValue === null
+      ? await requestToPromise(indexEntriesStore.getAll())
+      : await requestToPromise(
+          indexEntriesStore
+            .index(QUERY_INDEX_LOOKUP)
+            .getAll([collection, indexName, equalityValue]),
+        );
+
+  return rawEntries
+    .map((entry) => parseQueryIndexEntryRecord(entry))
+    .filter(
+      (entry) =>
+        entry.collection === collection &&
+        entry.indexName === indexName &&
+        matchesFilter(entry.indexValue, filter),
+    );
+}
+
+async function replaceQueryIndexEntries(
+  indexStore: IndexedDbObjectStoreLike,
+  collection: string,
+  key: string,
+  previousIndexes: ResolvedIndexKeys,
+  nextIndexes: ResolvedIndexKeys,
+): Promise<void> {
+  for (const indexName of Object.keys(previousIndexes)) {
+    await requestToPromise(indexStore.delete(makeQueryIndexEntryId(collection, indexName, key)));
+  }
+
+  for (const [indexName, rawValue] of Object.entries(nextIndexes)) {
+    const indexValue = String(rawValue);
+
+    await requestToPromise(
+      indexStore.put({
+        id: makeQueryIndexEntryId(collection, indexName, key),
+        collection,
+        indexName,
+        indexValue,
+        key,
+      }),
+    );
+  }
 }
 
 function assertUniqueIndexes(
@@ -908,6 +1094,22 @@ function matchesFilter(indexValue: string, filter: string | number | FieldCondit
   return matchesCondition(indexValue, filter);
 }
 
+function resolveEqualityFilterValue(filter: string | number | FieldCondition): string | null {
+  if (typeof filter === "string" || typeof filter === "number") {
+    return String(filter);
+  }
+
+  const entries = Object.entries(filter).filter(([, value]) => value !== undefined);
+
+  if (entries.length !== 1) {
+    return null;
+  }
+
+  const [operator, value] = entries[0]!;
+
+  return operator === "$eq" ? String(value as string | number) : null;
+}
+
 function matchesCondition(value: string, condition: FieldCondition): boolean {
   if (condition.$eq !== undefined && value !== String(condition.$eq as string | number)) {
     return false;
@@ -973,10 +1175,27 @@ async function openDatabase(
       if (!db.objectStoreNames.contains(STORE_MIGRATION_CHECKPOINTS)) {
         db.createObjectStore(STORE_MIGRATION_CHECKPOINTS, { keyPath: "collection" });
       }
+
+      if (!db.objectStoreNames.contains(STORE_QUERY_INDEX_ENTRIES)) {
+        const queryIndexEntries = db.createObjectStore(STORE_QUERY_INDEX_ENTRIES, {
+          keyPath: "id",
+        });
+
+        queryIndexEntries.createIndex(QUERY_INDEX_LOOKUP, [
+          "collection",
+          "indexName",
+          "indexValue",
+        ]);
+      }
     };
 
     request.onsuccess = () => {
-      resolve(request.result);
+      const db = request.result;
+
+      ensureQueryIndexEntriesBackfilled(db).then(
+        () => resolve(db),
+        (error: unknown) => reject(error),
+      );
     };
 
     request.onerror = () => {
@@ -1023,6 +1242,35 @@ function requestToPromise<T>(request: IndexedDbRequestLike<T>): Promise<T> {
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(toError(request.error, "IndexedDB request failed"));
   });
+}
+
+async function ensureQueryIndexEntriesBackfilled(db: IndexedDbDatabaseLike): Promise<void> {
+  await withTransaction(
+    db,
+    [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES],
+    "readwrite",
+    async (tx) => {
+      const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+      const existingEntries = await requestToPromise(indexStore.getAll());
+
+      if (existingEntries.length > 0) {
+        return;
+      }
+
+      const rawRecords = await requestToPromise(tx.objectStore(STORE_DOCUMENTS).getAll());
+
+      for (const rawRecord of rawRecords) {
+        const record = parseStoredDocumentRecord(rawRecord);
+        await replaceQueryIndexEntries(
+          indexStore,
+          record.collection,
+          record.key,
+          {},
+          record.indexes,
+        );
+      }
+    },
+  );
 }
 
 function resolveFactory(factory?: IndexedDbFactoryLike): IndexedDbFactoryLike {
@@ -1132,6 +1380,30 @@ function parseStoredDocumentRecord(value: unknown): StoredDocumentRecord {
   };
 }
 
+function parseQueryIndexEntryRecord(value: unknown): QueryIndexEntryRecord {
+  if (!isRecord(value)) {
+    throw new Error("IndexedDB query_index_entries store contains an invalid record");
+  }
+
+  const id = value.id;
+  const collection = value.collection;
+  const indexName = value.indexName;
+  const indexValue = value.indexValue;
+  const key = value.key;
+
+  if (
+    typeof id !== "string" ||
+    typeof collection !== "string" ||
+    typeof indexName !== "string" ||
+    typeof indexValue !== "string" ||
+    typeof key !== "string"
+  ) {
+    throw new Error("IndexedDB query_index_entries store contains an invalid record");
+  }
+
+  return { id, collection, indexName, indexValue, key };
+}
+
 function parseMigrationLockRecord(value: unknown): MigrationLockRecord {
   if (!isRecord(value)) {
     throw new Error("IndexedDB migration_locks store contains an invalid record");
@@ -1212,6 +1484,10 @@ function normalizeLimit(limit: number | undefined): number | null {
 
 function makeDocumentId(collection: string, key: string): string {
   return `${collection}\u0000${key}`;
+}
+
+function makeQueryIndexEntryId(collection: string, indexName: string, key: string): string {
+  return `${collection}\u0000${indexName}\u0000${key}`;
 }
 
 function randomId(): string {

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -32,6 +32,7 @@ interface RawOpenRequest<TDatabase> extends RawRequest<TDatabase> {
 }
 
 interface RawObjectStore {
+  getAll(): RawRequest<unknown[]>;
   put(value: unknown): RawRequest<unknown>;
 }
 
@@ -61,6 +62,100 @@ function createEngine(): IndexedDbQueryEngine {
     databaseName: currentDatabaseName,
     factory: fakeIndexedDB as unknown as IndexedDbFactory,
   });
+}
+
+function createDocumentGetAllGuardFactory() {
+  let blockDocumentGetAll = false;
+
+  const wrapObjectStore = (storeName: string, store: unknown): unknown => {
+    if (storeName !== RAW_STORE_DOCUMENTS) {
+      return store;
+    }
+
+    return new Proxy(store as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "getAll") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return () => {
+          if (blockDocumentGetAll) {
+            throw new Error("documents.getAll() should not be used for indexed query execution");
+          }
+
+          return (Reflect.get(target, property, receiver) as () => unknown).call(target);
+        };
+      },
+    });
+  };
+
+  const wrapTransaction = (transaction: unknown): unknown => {
+    return new Proxy(transaction as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "objectStore") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (storeName: string) => {
+          const objectStore = (
+            Reflect.get(target, property, receiver) as (name: string) => unknown
+          ).call(target, storeName);
+
+          return wrapObjectStore(storeName, objectStore);
+        };
+      },
+    });
+  };
+
+  const wrapDatabase = (database: unknown): unknown => {
+    return new Proxy(database as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "transaction") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (storeNames: string | string[], mode?: "readonly" | "readwrite") => {
+          const transaction = (
+            Reflect.get(target, property, receiver) as (
+              names: string | string[],
+              mode?: "readonly" | "readwrite",
+            ) => unknown
+          ).call(target, storeNames, mode);
+
+          return wrapTransaction(transaction);
+        };
+      },
+    });
+  };
+
+  const factory = {
+    open(name: string, version?: number) {
+      const request = (fakeIndexedDB as unknown as IndexedDbFactory).open(name, version);
+
+      return new Proxy(request as unknown as Record<string, unknown>, {
+        get(target, property, receiver) {
+          if (property === "result") {
+            return wrapDatabase(Reflect.get(target, property, receiver));
+          }
+
+          return Reflect.get(target, property, receiver);
+        },
+        set(target, property, value, receiver) {
+          return Reflect.set(target, property, value, receiver);
+        },
+      }) as unknown as ReturnType<IndexedDbFactory["open"]>;
+    },
+    deleteDatabase(name: string) {
+      return (fakeIndexedDB as unknown as IndexedDbFactory).deleteDatabase(name);
+    },
+  } satisfies IndexedDbFactory;
+
+  return {
+    factory,
+    blockDocumentGetAll() {
+      blockDocumentGetAll = true;
+    },
+  };
 }
 
 beforeEach(() => {
@@ -347,6 +442,29 @@ describe("indexedDbEngine query behavior", () => {
     });
 
     expect(results.documents).toEqual([{ key: "u1", doc: { id: "u1" } }]);
+  });
+
+  test("query with index equality avoids collection document loads", async () => {
+    const guarded = createDocumentGetAllGuardFactory();
+    const indexedEngine = indexedDbEngine({
+      databaseName: `${databaseNameBase}_guarded_${Date.now()}`,
+      factory: guarded.factory,
+    });
+
+    try {
+      await indexedEngine.put("users", "u1", { id: "u1" }, { status: "active" });
+      await indexedEngine.put("users", "u2", { id: "u2" }, { status: "inactive" });
+      guarded.blockDocumentGetAll();
+
+      const results = await indexedEngine.query("users", {
+        index: "status",
+        filter: { value: "active" },
+      });
+
+      expect(results.documents).toEqual([{ key: "u1", doc: { id: "u1" } }]);
+    } finally {
+      await indexedEngine.deleteDatabase();
+    }
   });
 
   test("query supports comparison filters", async () => {

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -66,9 +66,10 @@ function createEngine(): IndexedDbQueryEngine {
 
 function createDocumentGetAllGuardFactory() {
   let blockDocumentGetAll = false;
+  let blockQueryIndexEntriesGetAll = false;
 
   const wrapObjectStore = (storeName: string, store: unknown): unknown => {
-    if (storeName !== RAW_STORE_DOCUMENTS) {
+    if (storeName !== RAW_STORE_DOCUMENTS && storeName !== "query_index_entries") {
       return store;
     }
 
@@ -79,8 +80,14 @@ function createDocumentGetAllGuardFactory() {
         }
 
         return () => {
-          if (blockDocumentGetAll) {
+          if (storeName === RAW_STORE_DOCUMENTS && blockDocumentGetAll) {
             throw new Error("documents.getAll() should not be used for indexed query execution");
+          }
+
+          if (storeName === "query_index_entries" && blockQueryIndexEntriesGetAll) {
+            throw new Error(
+              "query_index_entries.getAll() should not be used for indexed query execution",
+            );
           }
 
           return (Reflect.get(target, property, receiver) as () => unknown).call(target);
@@ -154,6 +161,9 @@ function createDocumentGetAllGuardFactory() {
     factory,
     blockDocumentGetAll() {
       blockDocumentGetAll = true;
+    },
+    blockQueryIndexEntriesGetAll() {
+      blockQueryIndexEntriesGetAll = true;
     },
   };
 }
@@ -464,6 +474,58 @@ describe("indexedDbEngine query behavior", () => {
       expect(results.documents).toEqual([{ key: "u1", doc: { id: "u1" } }]);
     } finally {
       await indexedEngine.deleteDatabase();
+    }
+  });
+
+  test("query with comparison filters falls back instead of scanning all query index entries", async () => {
+    const guarded = createDocumentGetAllGuardFactory();
+    const indexedEngine = indexedDbEngine({
+      databaseName: `${databaseNameBase}_range_guarded_${Date.now()}`,
+      factory: guarded.factory,
+    });
+
+    try {
+      await indexedEngine.put("items", "a", { id: "a" }, { byDate: "2025-01-01" });
+      await indexedEngine.put("items", "b", { id: "b" }, { byDate: "2025-06-15" });
+      await indexedEngine.put("items", "c", { id: "c" }, { byDate: "2025-12-31" });
+      guarded.blockQueryIndexEntriesGetAll();
+
+      const results = await indexedEngine.query("items", {
+        index: "byDate",
+        filter: { value: { $between: ["2025-01-01", "2025-06-15"] } },
+      });
+
+      expect(results.documents.map((item) => item.key)).toEqual(["a", "b"]);
+    } finally {
+      await indexedEngine.deleteDatabase();
+    }
+  });
+
+  test("query index backfill completion does not depend on existing entry count", async () => {
+    const guarded = createDocumentGetAllGuardFactory();
+    const databaseName = `${databaseNameBase}_backfill_guarded_${Date.now()}`;
+    const firstEngine = indexedDbEngine({
+      databaseName,
+      factory: guarded.factory,
+    });
+
+    try {
+      await firstEngine.put("users", "u1", { id: "u1" }, {});
+      firstEngine.close();
+      guarded.blockDocumentGetAll();
+
+      const reopenedEngine = indexedDbEngine({
+        databaseName,
+        factory: guarded.factory,
+      });
+
+      try {
+        expect(await reopenedEngine.get("users", "u1")).toEqual({ id: "u1" });
+      } finally {
+        await reopenedEngine.deleteDatabase();
+      }
+    } finally {
+      firstEngine.close();
     }
   });
 


### PR DESCRIPTION
## Summary
- Closes #121.
- Adds a `query_index_entries` IndexedDB object store that mirrors each document's resolved index keys.
- Routes indexed queries through the index-entry store and fetches only matching document records, keeping full collection document loads as the fallback for scan queries.
- Backfills query index entries when opening an upgraded database whose new index-entry store is empty.
- Adds integration coverage that guards indexed equality queries against `documents.getAll()` collection loads.

## Why
The IndexedDB adapter previously evaluated all indexed queries by loading every document in the collection and filtering in memory. That made query cost scale with collection size and caused unnecessary browser memory pressure. The new secondary store gives IndexedDB a queryable key lookup path while preserving existing query semantics and cursor behavior.

## Validation
- `bun fmt`
- `bun lint:fix` (completed with 7 existing warnings in unrelated MySQL/DynamoDB/SQLite tests)
- `bun run test`
- `bun run test:integration:indexeddb`
- `bun typecheck`
- `git diff --check`

## Note
A direct `bun test` invocation was also attempted, but that command runs service-backed integration suites in this checkout and failed because local MySQL/Firestore/Cassandra services were not running. The package unit-test script `bun run test` passed.