### PR TITLE
[codex] Replace Buffer usage in query cursors

### DIFF
--- a/.changeset/browser-query-cursors.md
+++ b/.changeset/browser-query-cursors.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Replace query cursor Buffer encoding with a runtime-neutral base64url codec for browser-compatible adapters.

--- a/src/engines/query-cursor.ts
+++ b/src/engines/query-cursor.ts
@@ -44,7 +44,7 @@ export function encodeQueryPageCursor(
     position: buildCursorPosition(params, position),
   };
 
-  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return encodeBase64Url(JSON.stringify(payload));
 }
 
 export function resolveQueryPageStartIndex<TRecord>(
@@ -197,7 +197,7 @@ function decodeQueryPageCursor(encoded: string): QueryCursorPayload {
   let parsed: unknown;
 
   try {
-    parsed = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"));
+    parsed = JSON.parse(decodeBase64Url(encoded));
   } catch {
     throw new Error("Invalid query cursor");
   }
@@ -309,4 +309,24 @@ function stableSerialize(value: unknown): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function encodeBase64Url(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  const binary = Array.from(bytes, (byte) => String.fromCharCode(byte)).join("");
+
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function decodeBase64Url(value: string): string {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
+  const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+
+  for (const [index, char] of Array.from(binary).entries()) {
+    bytes[index] = char.charCodeAt(0);
+  }
+
+  return new TextDecoder().decode(bytes);
 }

--- a/src/engines/query-cursor.ts
+++ b/src/engines/query-cursor.ts
@@ -322,11 +322,7 @@ function decodeBase64Url(value: string): string {
   const base64 = value.replaceAll("-", "+").replaceAll("_", "/");
   const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), "=");
   const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-
-  for (const [index, char] of Array.from(binary).entries()) {
-    bytes[index] = char.charCodeAt(0);
-  }
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
 
   return new TextDecoder().decode(bytes);
 }

--- a/tests/unit/query-cursor.test.ts
+++ b/tests/unit/query-cursor.test.ts
@@ -23,6 +23,34 @@ function position(record: FakeRecord, params: QueryParams): QueryCursorRecordPos
 }
 
 describe("query cursor helpers", () => {
+  test("encodes and decodes cursors without the Node Buffer global", () => {
+    const originalBuffer = Object.getOwnPropertyDescriptor(globalThis, "Buffer");
+
+    // Browser-targeted adapters should not require bundlers to polyfill Buffer.
+    Reflect.deleteProperty(globalThis, "Buffer");
+
+    try {
+      const params: QueryParams = {
+        index: "byScore",
+        filter: { value: { $gte: "10" } },
+        sort: "asc",
+        limit: 2,
+      };
+      const records: FakeRecord[] = [
+        { key: "a", createdAt: 1, indexes: { byScore: "10" } },
+        { key: "b", createdAt: 2, indexes: { byScore: "10" } },
+        { key: "c", createdAt: 3, indexes: { byScore: "11" } },
+      ];
+      const cursor = encodeQueryPageCursor("items", params, position(records[1]!, params));
+
+      expect(resolveQueryPageStartIndex(records, "items", { ...params, cursor }, position)).toBe(2);
+    } finally {
+      if (originalBuffer) {
+        Object.defineProperty(globalThis, "Buffer", originalBuffer);
+      }
+    }
+  });
+
   test("rejects malformed cursors explicitly", () => {
     const records: FakeRecord[] = [];
 


### PR DESCRIPTION
## Summary

Fixes #134 by replacing the shared query cursor `Buffer` encoding/decoding path with a runtime-neutral base64url codec built on `TextEncoder`, `TextDecoder`, `btoa`, and `atob`.

## Root Cause

`src/engines/query-cursor.ts` encoded and decoded opaque query cursor payloads with Node's `Buffer` global. Browser-targeted adapters such as IndexedDB can run in environments where `Buffer` is not present unless a bundler injects a Node polyfill, causing cursor pagination to fail at runtime.

## Changes

- Removed direct `Buffer.from(...).toString("base64url")` usage from shared query cursor helpers.
- Added runtime-neutral base64url encode/decode helpers that preserve the existing JSON cursor payload format.
- Added a regression test that deletes `globalThis.Buffer` and verifies cursor encode/decode pagination still works.
- Added a patch changeset for the browser compatibility fix.

## Validation

- `bun fmt`
- `bun lint:fix` (completed with existing warning-level await-thenable findings in unrelated tests)
- `bun test ./tests/unit/query-cursor.test.ts`
- `bun run test`
- `bun typecheck`
- `bun run test:integration:indexeddb`
- `bun run build` (completed with existing neutral-platform unresolved `node:crypto` warnings for MySQL/Firestore)