### PR TITLE
[codex] Reject store API model name collisions

### DIFF
--- a/.changeset/reject-store-api-model-names.md
+++ b/.changeset/reject-store-api-model-names.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Reject model names that collide with store-level migration APIs.

--- a/src/store.ts
+++ b/src/store.ts
@@ -186,6 +186,13 @@ export type Store<
   migrateAll(options?: MigrationRunOptions): Promise<MigrationResult[]>;
 };
 
+const RESERVED_STORE_API_NAMES = new Set([
+  "getOrCreateMigration",
+  "migrateNextPage",
+  "getMigrationProgress",
+  "migrateAll",
+]);
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
@@ -1907,6 +1914,10 @@ export function createStore<
   const boundModels = new Map<string, BoundModelImpl<any, TOptions, any, any>>();
 
   for (const modelDef of models) {
+    if (RESERVED_STORE_API_NAMES.has(modelDef.name)) {
+      throw new Error(`Model name "${modelDef.name}" collides with a store-level API`);
+    }
+
     if (boundModels.has(modelDef.name)) {
       throw new Error(`Duplicate model name: "${modelDef.name}"`);
     }

--- a/src/store.ts
+++ b/src/store.ts
@@ -186,6 +186,7 @@ export type Store<
   migrateAll(options?: MigrationRunOptions): Promise<MigrationResult[]>;
 };
 
+// Keep in sync with the store-level methods declared in the `Store` type above.
 const RESERVED_STORE_API_NAMES = new Set([
   "getOrCreateMigration",
   "migrateNextPage",

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -627,6 +627,31 @@ describe("createStore()", () => {
     }).toThrow('Duplicate model name: "user"');
   });
 
+  test("throws when model names collide with store-level APIs", () => {
+    const reservedNames = [
+      "getOrCreateMigration",
+      "migrateNextPage",
+      "getMigrationProgress",
+      "migrateAll",
+    ] as const;
+
+    for (const reservedName of reservedNames) {
+      const reservedModel = model(reservedName)
+        .schema(
+          1,
+          z.object({
+            id: z.string(),
+          }),
+        )
+        .index({ name: "primary", value: "id" })
+        .build();
+
+      expect(() => {
+        createStore(engine, [reservedModel]);
+      }).toThrow(`Model name "${reservedName}" collides with a store-level API`);
+    }
+  });
+
   test("creates a store with a single model", () => {
     const store = createStore(engine, [buildUserV1()]);
 


### PR DESCRIPTION
## Summary

Fixes #135.

`createStore()` now rejects model names that collide with store-level migration APIs before binding model accessors onto the store object. This prevents a model named `migrateAll`, `migrateNextPage`, `getOrCreateMigration`, or `getMigrationProgress` from overwriting the store-level API.

## Root Cause

Store-level methods were created first, then bound models were assigned onto the same object by model name without checking whether the model name was already reserved by the store API.

## Changes

- Added a reserved store API name set in `src/store.ts`.
- Added `createStore()` validation for reserved model names.
- Added regression coverage for every store-level migration API name.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint` (passes with existing warning-only findings in unrelated MySQL/DynamoDB/SQLite tests)
- `bun run test`
- `bun typecheck`