### PR TITLE
[codex] Make memory batchSet atomic

### DIFF
--- a/.changeset/atomic-memory-batchset.md
+++ b/.changeset/atomic-memory-batchset.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Make memory engine batchSet writes atomic when per-item write preparation fails.

--- a/src/engines/memory.ts
+++ b/src/engines/memory.ts
@@ -26,6 +26,11 @@ interface StoredDocument {
   uniqueIndexes: ResolvedIndexKeys;
 }
 
+interface StagedBatchSetItem {
+  readonly key: string;
+  readonly stored: StoredDocument;
+}
+
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
@@ -283,6 +288,8 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
       const col = getCollection(collection);
       const collectionUniqueState = getCollectionUniqueOwnership(collection);
       const stagedUniqueState = cloneUniqueOwnershipState(collectionUniqueState);
+      const stagedItems: StagedBatchSetItem[] = [];
+      let stagedCreatedAtSequence = createdAtSequence;
 
       // Validate unique constraints for the whole batch up front so duplicate
       // unique values fail before any write is applied.
@@ -293,16 +300,28 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
       for (const item of items) {
         engineOptions.onBeforePut?.(collection, item.key, item.doc);
 
-        reserveUniqueIndexes(collection, item.key, item.uniqueIndexes ?? {}, collectionUniqueState);
         const existing = col.get(item.key);
-
-        col.set(item.key, {
-          createdAt: existing?.createdAt ?? ++createdAtSequence,
-          doc: cloneStoredDocument(item.doc),
-          indexes: { ...item.indexes },
-          uniqueIndexes: { ...item.uniqueIndexes },
+        stagedItems.push({
+          key: item.key,
+          stored: {
+            createdAt: existing?.createdAt ?? ++stagedCreatedAtSequence,
+            doc: cloneStoredDocument(item.doc),
+            indexes: { ...item.indexes },
+            uniqueIndexes: { ...item.uniqueIndexes },
+          },
         });
       }
+
+      collectionUniqueState.clear();
+      for (const [indexName, ownerByValue] of stagedUniqueState) {
+        collectionUniqueState.set(indexName, ownerByValue);
+      }
+
+      for (const item of stagedItems) {
+        col.set(item.key, item.stored);
+      }
+
+      createdAtSequence = stagedCreatedAtSequence;
     },
 
     async batchDelete(collection, keys) {

--- a/src/engines/memory.ts
+++ b/src/engines/memory.ts
@@ -289,6 +289,7 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
       const collectionUniqueState = getCollectionUniqueOwnership(collection);
       const stagedUniqueState = cloneUniqueOwnershipState(collectionUniqueState);
       const stagedItems: StagedBatchSetItem[] = [];
+      const stagedItemByKey = new Map<string, StagedBatchSetItem>();
       let stagedCreatedAtSequence = createdAtSequence;
 
       // Validate unique constraints for the whole batch up front so duplicate
@@ -300,8 +301,8 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
       for (const item of items) {
         engineOptions.onBeforePut?.(collection, item.key, item.doc);
 
-        const existing = col.get(item.key);
-        stagedItems.push({
+        const existing = stagedItemByKey.get(item.key)?.stored ?? col.get(item.key);
+        const stagedItem = {
           key: item.key,
           stored: {
             createdAt: existing?.createdAt ?? ++stagedCreatedAtSequence,
@@ -309,7 +310,10 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
             indexes: { ...item.indexes },
             uniqueIndexes: { ...item.uniqueIndexes },
           },
-        });
+        };
+
+        stagedItems.push(stagedItem);
+        stagedItemByKey.set(item.key, stagedItem);
       }
 
       collectionUniqueState.clear();

--- a/tests/integration/memory-engine.test.ts
+++ b/tests/integration/memory-engine.test.ts
@@ -398,6 +398,25 @@ describe("batchSet()", () => {
     expect(stored.nested.value).toBe(1);
   });
 
+  test("preserves the first createdAt when a batch contains duplicate new keys", async () => {
+    await engine.batchSet!("users", [
+      { key: "a", doc: { id: "a", name: "First" }, indexes: { byGroup: "same" } },
+      { key: "b", doc: { id: "b", name: "Second" }, indexes: { byGroup: "same" } },
+      { key: "a", doc: { id: "a", name: "Updated" }, indexes: { byGroup: "same" } },
+    ]);
+
+    const results = await engine.query("users", {
+      index: "byGroup",
+      filter: { value: "same" },
+      sort: "asc",
+    });
+
+    expect(results.documents).toEqual([
+      { key: "a", doc: { id: "a", name: "Updated" } },
+      { key: "b", doc: { id: "b", name: "Second" } },
+    ]);
+  });
+
   test("does not persist any documents when write preparation fails", async () => {
     engine = memoryEngine({
       onBeforePut(_collection, key) {
@@ -407,16 +426,16 @@ describe("batchSet()", () => {
       },
     });
 
-    try {
-      await engine.batchSet!("users", [
-        { key: "a", doc: { id: "a", name: "Alice" }, indexes: { primary: "a" } },
-        { key: "b", doc: { id: "b", name: "Bob" }, indexes: { primary: "b" } },
-      ]);
-      throw new Error("expected batchSet to fail");
-    } catch (error) {
-      expect(error).toBeInstanceOf(Error);
-      expect((error as Error).message).toBe("write preparation failed");
-    }
+    const rejection = expect(
+      Promise.resolve().then(() =>
+        engine.batchSet!("users", [
+          { key: "a", doc: { id: "a", name: "Alice" }, indexes: { primary: "a" } },
+          { key: "b", doc: { id: "b", name: "Bob" }, indexes: { primary: "b" } },
+        ]),
+      ),
+    ).rejects.toThrow("write preparation failed") as unknown as Promise<void>;
+
+    await rejection;
 
     expect(await engine.get("users", "a")).toBeNull();
     expect(await engine.get("users", "b")).toBeNull();

--- a/tests/integration/memory-engine.test.ts
+++ b/tests/integration/memory-engine.test.ts
@@ -397,6 +397,30 @@ describe("batchSet()", () => {
 
     expect(stored.nested.value).toBe(1);
   });
+
+  test("does not persist any documents when write preparation fails", async () => {
+    engine = memoryEngine({
+      onBeforePut(_collection, key) {
+        if (key === "b") {
+          throw new Error("write preparation failed");
+        }
+      },
+    });
+
+    try {
+      await engine.batchSet!("users", [
+        { key: "a", doc: { id: "a", name: "Alice" }, indexes: { primary: "a" } },
+        { key: "b", doc: { id: "b", name: "Bob" }, indexes: { primary: "b" } },
+      ]);
+      throw new Error("expected batchSet to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("write preparation failed");
+    }
+
+    expect(await engine.get("users", "a")).toBeNull();
+    expect(await engine.get("users", "b")).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/migration-recovery.test.ts
+++ b/tests/unit/migration-recovery.test.ts
@@ -138,7 +138,7 @@ describe("migration crash recovery — single page", () => {
     // First attempt crashes mid-page
     await expectReject(store1.user.migrateAll(), SimulatedCrashError);
 
-    // 3 documents were migrated before the crash
+    // batchSet is atomic, so the failed page is rolled back.
     let migratedCount = 0;
     let staleCount = 0;
 
@@ -153,18 +153,18 @@ describe("migration crash recovery — single page", () => {
       }
     }
 
-    expect(migratedCount).toBe(3);
-    expect(staleCount).toBe(7);
+    expect(migratedCount).toBe(0);
+    expect(staleCount).toBe(10);
 
     // Remove the failure hook
     engine.setOptions({});
 
-    // Retry — should succeed and migrate the remaining 7
+    // Retry — should succeed and migrate the full page.
     const store2 = createStore(engine, [buildUserV2()]);
     const result = await store2.user.migrateAll();
 
     expect(result.status).toBe("completed");
-    expect(result.migrated).toBe(7);
+    expect(result.migrated).toBe(10);
 
     // All documents should now be v2
     for (let i = 0; i < 10; i++) {
@@ -245,8 +245,8 @@ describe("migration crash recovery — multi-page", () => {
       }
     }
 
-    // 110 docs migrated (100 from first page + 10 from second)
-    expect(migratedCount).toBe(110);
+    // The first page committed, but the failed second page was rolled back.
+    expect(migratedCount).toBe(100);
 
     // Checkpoint should have been saved after first page
     const checkpoint = await engine.migration.loadCheckpoint!("user");
@@ -259,10 +259,9 @@ describe("migration crash recovery — multi-page", () => {
     const result = await store2.user.migrateAll();
 
     expect(result.status).toBe("completed");
-    // Should only migrate the remaining 40 (50 on page 2, minus 10 already done)
-    // But since checkpoint resumes at page boundary, it re-scans page 2 (50 docs)
-    // and skips the 10 already migrated, migrating the remaining 40
-    expect(result.migrated).toBe(40);
+    // Checkpoint resumes after the committed first page, so the full second
+    // page is migrated on retry.
+    expect(result.migrated).toBe(50);
 
     // All should be v2 now
     for (let i = 0; i < 150; i++) {
@@ -309,7 +308,7 @@ describe("migration crash recovery — multi-page", () => {
       }
     }
 
-    expect(migratedCount).toBe(205);
+    expect(migratedCount).toBe(100);
 
     // Retry
     engine.setOptions({});
@@ -318,7 +317,7 @@ describe("migration crash recovery — multi-page", () => {
     const result = await store2.user.migrateAll();
 
     expect(result.status).toBe("completed");
-    expect(result.migrated).toBe(45); // 50 on page 3, minus 5 already done
+    expect(result.migrated).toBe(150);
 
     // All migrated
     for (let i = 0; i < 250; i++) {
@@ -379,7 +378,7 @@ describe("migration recovery — multiple sequential crashes", () => {
     const store3 = createStore(engine, [buildUserV2()]);
     await expectReject(store3.user.migrateAll(), SimulatedCrashError);
 
-    // Some progress has been made — at least some docs should be migrated
+    // Every crash rolls back its page, so no document-level progress is visible.
     let migratedSoFar = 0;
 
     for (let i = 0; i < 20; i++) {
@@ -389,8 +388,7 @@ describe("migration recovery — multiple sequential crashes", () => {
       if (raw.__v === 2) migratedSoFar++;
     }
 
-    expect(migratedSoFar).toBeGreaterThan(0);
-    expect(migratedSoFar).toBeLessThan(20);
+    expect(migratedSoFar).toBe(0);
 
     // Final attempt: no crash
     engine.setOptions({});
@@ -455,18 +453,11 @@ describe("migration idempotency", () => {
     await expectReject(store1.user.migrateAll(), SimulatedCrashError);
 
     // Track which IDs get written on retry and whether they were stale
-    const retryMigratedIds: string[] = [];
-    const retryReindexedIds: string[] = [];
+    const retryWrittenIds: string[] = [];
     engine.setOptions({
-      onBeforePut(collection, id, doc) {
+      onBeforePut(collection, id) {
         if (collection === "user") {
-          const d = doc as Record<string, unknown>;
-          // If __v < 2 before being written, it was a migration; otherwise index recompute
-          if ((d as any).__v === 2) {
-            retryReindexedIds.push(id);
-          } else {
-            retryMigratedIds.push(id);
-          }
+          retryWrittenIds.push(id);
         }
       },
     });
@@ -474,12 +465,12 @@ describe("migration idempotency", () => {
     const store2 = createStore(engine, [buildUserV2()]);
     await store2.user.migrateAll();
 
-    // Already-migrated docs from the first run should be reindexed (not
-    // re-migrated) on retry — their schema version stays the same.
+    // The first run rolled back atomically, so previously attempted writes are
+    // retried rather than treated as already migrated.
     const firstRunMigrated = migratedIds.slice(0, 5);
 
     for (const id of firstRunMigrated) {
-      expect(retryMigratedIds).not.toContain(id);
+      expect(retryWrittenIds).toContain(id);
     }
   });
 });
@@ -631,14 +622,14 @@ describe("migration crash recovery — multi-version chain", () => {
     const store1 = createStore(engine, [buildUserV3()]);
     await expectReject(store1.user.migrateAll(), SimulatedCrashError);
 
-    // 4 docs migrated to v3
+    // The failed batch rolls back atomically.
     let migratedCount = 0;
     for (let i = 0; i < 10; i++) {
       const id = `u${String(i).padStart(4, "0")}`;
       const raw = (await engine.get("user", id)) as Record<string, unknown>;
       if (raw.__v === 3) migratedCount++;
     }
-    expect(migratedCount).toBe(4);
+    expect(migratedCount).toBe(0);
 
     engine.setOptions({});
 
@@ -646,7 +637,7 @@ describe("migration crash recovery — multi-version chain", () => {
     const result = await store2.user.migrateAll();
 
     expect(result.status).toBe("completed");
-    expect(result.migrated).toBe(6);
+    expect(result.migrated).toBe(10);
 
     // All docs should be v3 with role field
     for (let i = 0; i < 10; i++) {
@@ -807,8 +798,7 @@ describe("checkpoint lifecycle", () => {
     const result = await store2.user.migrateAll();
 
     expect(result.status).toBe("completed");
-    // 10 were already migrated, so only 40 remain
-    expect(result.migrated).toBe(40);
+    expect(result.migrated).toBe(50);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #136.

This changes the memory engine `batchSet` implementation so per-item write preparation failures cannot leave earlier items partially persisted. The engine now stages unique ownership, document clones, and generated `createdAt` values before mutating the live collection, then commits the staged state only after every item has prepared successfully.

## Root cause

`memoryEngine.batchSet()` validated unique constraints up front, but the actual write loop still called `onBeforePut`, updated unique ownership, cloned the document, and wrote each item directly into the live collection. If `onBeforePut` or cloning failed after an earlier item had been written, the batch was left partially committed.

## Changes

- Stage `batchSet` writes in memory before mutating the collection.
- Commit staged unique ownership and document entries only after all per-item preparation succeeds.
- Preserve `createdAt` sequencing by staging the sequence counter and committing it only on success.
- Add a regression test where `onBeforePut` fails on the second item and assert neither item is persisted.
- Update migration recovery tests to reflect atomic page rollback for memory-engine batch writes.
- Add the required patch changeset.

## Validation

- `bun fmt`
- `bun lint` exits successfully; it reports 7 existing warnings in unrelated DynamoDB/SQLite/MySQL tests.
- `bun typecheck`
- `bun run test`
- `bun run test:integration:memory`