### PR TITLE
[codex] Validate dynamic index names

### DIFF
--- a/.changeset/validate-dynamic-index-names.md
+++ b/.changeset/validate-dynamic-index-names.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Validate dynamic index names before resolving index entries for writes.

--- a/src/model.ts
+++ b/src/model.ts
@@ -411,8 +411,16 @@ export class ModelDefinition<
       // For static-name indexes, the resolved name equals the key.
       // For dynamic-name indexes, the resolved name is computed from document data,
       // and becomes the engine-level index identifier for this document.
-      const resolvedName = typeof index.name === "function" ? index.name(data) : index.name;
       const sourceIdentifier = this.describeIndexIdentifier(index);
+      const resolvedName =
+        typeof index.name === "function"
+          ? resolveDynamicIndexName(
+              index.name as (data: T) => unknown,
+              data,
+              this.name,
+              sourceIdentifier,
+            )
+          : index.name;
       const existingSource = resolvedSources.get(resolvedName);
 
       if (existingSource) {
@@ -804,6 +812,35 @@ function resolveIndexValue<T>(
   }
 
   return String(fieldValue as string | number | boolean | bigint | symbol);
+}
+
+function resolveDynamicIndexName<T>(
+  name: (data: T) => unknown,
+  data: T,
+  modelName: string,
+  indexIdentifier: string,
+): string {
+  const resolved = name(data);
+
+  if (typeof resolved !== "string") {
+    throw new Error(
+      `Model "${modelName}" ${indexIdentifier} dynamic index name must resolve to a non-empty string, got ${formatIndexValueType(resolved)}`,
+    );
+  }
+
+  if (resolved.length === 0) {
+    throw new Error(
+      `Model "${modelName}" ${indexIdentifier} dynamic index name must resolve to a non-empty string`,
+    );
+  }
+
+  if (resolved.includes("\u0000")) {
+    throw new Error(
+      `Model "${modelName}" ${indexIdentifier} dynamic index name must not contain the reserved index separator`,
+    );
+  }
+
+  return resolved;
 }
 
 function formatIndexValueType(value: unknown): string {

--- a/tests/unit/model.test.ts
+++ b/tests/unit/model.test.ts
@@ -1156,7 +1156,7 @@ describe("edge cases", () => {
     );
   });
 
-  test("dynamic index name returning empty string", () => {
+  test("throws when dynamic index name returns an empty string", () => {
     const m = model("item")
       .schema(1, z.object({ id: z.string() }))
       .index("empty_v1", {
@@ -1165,9 +1165,44 @@ describe("edge cases", () => {
       })
       .build();
 
-    const keys = m.resolveIndexKeys({ id: "abc" });
+    expect(() => m.resolveIndexKeys({ id: "abc" })).toThrow(
+      'Model "item" dynamic index key "empty_v1" dynamic index name must resolve to a non-empty string',
+    );
+  });
 
-    expect(keys).toEqual({ "": "val" });
+  test.each([
+    [undefined, "undefined"],
+    [null, "null"],
+    [123, "number"],
+    [true, "boolean"],
+    [{}, "object"],
+    [[], "array"],
+  ])("throws when dynamic index name returns %s", (resolved, label) => {
+    const m = model("item")
+      .schema(1, z.object({ id: z.string() }))
+      .index("bad_name_v1", {
+        name: () => resolved as never,
+        value: () => "val",
+      })
+      .build();
+
+    expect(() => m.resolveIndexKeys({ id: "abc" })).toThrow(
+      `Model "item" dynamic index key "bad_name_v1" dynamic index name must resolve to a non-empty string, got ${label}`,
+    );
+  });
+
+  test("throws when dynamic index name contains the reserved index separator", () => {
+    const m = model("item")
+      .schema(1, z.object({ id: z.string() }))
+      .index("bad_separator_v1", {
+        name: () => "tenant\u0000user",
+        value: () => "val",
+      })
+      .build();
+
+    expect(() => m.resolveIndexKeys({ id: "abc" })).toThrow(
+      'Model "item" dynamic index key "bad_separator_v1" dynamic index name must not contain the reserved index separator',
+    );
   });
 
   test("dynamic index name: unique flag is preserved", () => {


### PR DESCRIPTION
## Summary

Fixes #139 by validating dynamic index names at resolution time before resolved index entries are handed to storage engines.

## What changed

- Added runtime validation for dynamic index name functions in `src/model.ts`.
- Reject dynamic index names that resolve to non-strings, empty strings, or values containing the internal index separator (`\u0000`).
- Include the dynamic index key in the error message so invalid model definitions are easier to diagnose.
- Added regression tests covering empty, non-string, and reserved-separator dynamic name outputs.
- Added a patch changeset for the package.

## Root cause

Dynamic index names were computed from document data and then used directly as keys in resolved engine index maps. Invalid return values such as `undefined`, non-string values, or an empty string could therefore create malformed index entries or adapter-specific behavior instead of failing near the write path.

## Validation

- `bun test ./tests/unit/model.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`