### PR TITLE
[codex] Validate query limit values in store

### DIFF
--- a/.changeset/validate-query-limit-values.md
+++ b/.changeset/validate-query-limit-values.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Validate query limit values in the store layer before dispatching to engines.

--- a/src/engines/types.ts
+++ b/src/engines/types.ts
@@ -162,6 +162,7 @@ export interface QueryParams {
   filter?: QueryFilter;
   /** Field-level filter — resolves the index automatically. Mutually exclusive with `index`/`filter`. */
   where?: WhereFilter;
+  /** Maximum documents to return. Must be a finite, non-negative integer; 0 returns an empty page. */
   limit?: number;
   cursor?: string;
   sort?: "asc" | "desc";

--- a/src/store.ts
+++ b/src/store.ts
@@ -1688,10 +1688,12 @@ class BoundModelImpl<
       throw new Error('query params with "filter" must also include "index"');
     }
 
+    const limit = this.normalizeQueryLimit(params.limit);
+
     if (hasWhere) {
       return {
         ...this.resolveWhere(params.where!),
-        limit: params.limit,
+        limit,
         cursor: params.cursor,
         querySignatureSalt: this.currentQuerySignatureSalt(),
         sort: params.sort,
@@ -1701,6 +1703,7 @@ class BoundModelImpl<
     if (hasIndex) {
       return {
         ...params,
+        limit,
         index: this.resolveIndexName(params.index!),
         querySignatureSalt: this.currentQuerySignatureSalt(),
       };
@@ -1708,8 +1711,21 @@ class BoundModelImpl<
 
     return {
       ...params,
+      limit,
       querySignatureSalt: this.currentQuerySignatureSalt(),
     };
+  }
+
+  private normalizeQueryLimit(limit: number | undefined): number | undefined {
+    if (limit === undefined) {
+      return undefined;
+    }
+
+    if (!Number.isFinite(limit) || limit < 0 || !Number.isInteger(limit)) {
+      throw new Error("query limit must be a finite, non-negative integer");
+    }
+
+    return limit;
   }
 
   // Resolves a user-facing index name to the engine-level index identifier.

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -1983,6 +1983,53 @@ describe("store.query()", () => {
     expect(page2.cursor).toBeNull();
   });
 
+  test("rejects invalid query limits before dispatching to the engine", async () => {
+    const forwardedLimits: number[] = [];
+    const trackingEngine: QueryEngine<never> = {
+      async get() {
+        return null;
+      },
+      async create() {},
+      async put() {},
+      async update() {},
+      async delete() {},
+      async query(_collection, params) {
+        if (params.limit !== undefined) {
+          forwardedLimits.push(params.limit);
+        }
+
+        return { documents: [], cursor: null };
+      },
+      async batchGet() {
+        return [];
+      },
+      async batchSet() {},
+      async batchDelete() {},
+      migration: {
+        async acquireLock() {
+          return null;
+        },
+        async releaseLock() {},
+        async getOutdated() {
+          return { documents: [], cursor: null };
+        },
+      },
+    };
+    const store = createStore(trackingEngine, [buildUserV1()]);
+
+    for (const limit of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, -1, 1.5]) {
+      await expectReject(
+        store.user.query({ limit }),
+        "query limit must be a finite, non-negative integer",
+      );
+    }
+
+    await store.user.query({ limit: 0 });
+    await store.user.query({ limit: 2 });
+
+    expect(forwardedLimits).toEqual([0, 2]);
+  });
+
   test("projects read results with bounded concurrency while preserving document order", async () => {
     const tracker = createReadProjectionTracker();
     const migratedDocs = createMigratedUserDocuments(10);


### PR DESCRIPTION
## Summary

Fixes #141.

This adds store-level validation for query `limit` values before resolved query params are dispatched to any engine. The store now rejects `NaN`, `Infinity`, `-Infinity`, negative values, and fractional values with a consistent error, while preserving valid `0` and positive integer limits.

## Details

- Centralizes query limit validation in `BoundModelImpl.resolveQuery` so scan, index/filter, and `where` query paths share the same behavior.
- Documents the public `QueryParams.limit` contract as a finite, non-negative integer where `0` returns an empty page.
- Adds a regression test proving invalid limits are rejected before engine dispatch and valid limits are forwarded unchanged.
- Adds a patch changeset for the behavior change.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`