### PR TITLE
[codex] Use frozen installs for publish gates

### DIFF
--- a/.changeset/frozen-publish-gates.md
+++ b/.changeset/frozen-publish-gates.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Use frozen Bun installs for all publish-gating jobs so release checks validate the lockfile dependency graph.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# Publish gates must install from the lockfile to validate the released dependency graph.
 jobs:
   quality:
     runs-on: ubuntu-latest
@@ -26,7 +27,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run lint check
         run: bun run lint
@@ -50,7 +51,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run unit test suite
         run: bun run test
@@ -71,7 +72,7 @@ jobs:
           bun-version: latest
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run integration smoke test (${{ matrix.engine }})
         run: bun run test:integration:${{ matrix.engine }}


### PR DESCRIPTION
## Summary

Fixes #142.

Updates the publish workflow so every publish-gating job installs dependencies with `bun install --frozen-lockfile` before running release-blocking checks.

## Root cause

The publish workflow already used a frozen install in the final release job, but the preceding quality, unit, and integration smoke jobs used plain `bun install`. That meant release gates could validate a dependency graph that differed from the committed lockfile before the release job ran.

## Changes

- Changed the `quality`, `unit-tests`, and `integration-smoke` install steps in `.github/workflows/publish.yml` to use `bun install --frozen-lockfile`.
- Added a workflow comment documenting that publish gates must validate the lockfile dependency graph.
- Added a changeset for the release-gating reproducibility fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun run test:integration:memory`
- `bun run test:integration:indexeddb`
- `bun run test:integration:sqlite`