### PR TITLE
[codex] Add IndexedDB optimistic write tokens

### DIFF
--- a/.changeset/bright-timers-hunt.md
+++ b/.changeset/bright-timers-hunt.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Add optimistic write-token support to the IndexedDB adapter so stale conditional writes are reported as conflicts instead of overwriting newer documents.

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -535,7 +535,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
             if (
               item.expectedWriteToken !== undefined &&
-              String(existing?.writeVersion) !== item.expectedWriteToken
+              (existing === undefined || String(existing.writeVersion) !== item.expectedWriteToken)
             ) {
               conflictedKeys.push(item.key);
               continue;

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -114,6 +114,7 @@ interface StoredDocumentRecord {
   collection: string;
   key: string;
   createdAt: number;
+  writeVersion: number;
   doc: Record<string, unknown>;
   indexes: ResolvedIndexKeys;
   uniqueIndexes: ResolvedIndexKeys;
@@ -188,6 +189,26 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       });
     },
 
+    async getWithMetadata(collection, key) {
+      const db = await dbPromise;
+      const docId = makeDocumentId(collection, key);
+
+      return withTransaction(db, [STORE_DOCUMENTS], "readonly", async (tx) => {
+        const raw = await requestToPromise(tx.objectStore(STORE_DOCUMENTS).get(docId));
+
+        if (raw === undefined) {
+          return null;
+        }
+
+        const record = parseStoredDocumentRecord(raw);
+
+        return {
+          doc: structuredClone(record.doc),
+          writeToken: String(record.writeVersion),
+        };
+      });
+    },
+
     async create(collection, key, doc, indexes, _options, _migrationMetadata, uniqueIndexes) {
       const db = await dbPromise;
       const docId = makeDocumentId(collection, key);
@@ -217,6 +238,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             collection,
             key,
             createdAt: sequence,
+            writeVersion: 1,
             doc,
             indexes,
             uniqueIndexes,
@@ -247,14 +269,17 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
           const existingRaw = await requestToPromise(docsStore.get(docId));
 
           let createdAt: number;
+          let writeVersion: number;
           let existingIndexes: ResolvedIndexKeys = {};
 
           if (existingRaw === undefined) {
             createdAt = (await loadSequence(metaStore)) + 1;
+            writeVersion = 1;
             await saveSequence(metaStore, createdAt);
           } else {
             const existing = parseStoredDocumentRecord(existingRaw);
             createdAt = existing.createdAt;
+            writeVersion = existing.writeVersion + 1;
             existingIndexes = existing.indexes;
           }
 
@@ -265,6 +290,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             collection,
             key,
             createdAt,
+            writeVersion,
             doc,
             indexes,
             uniqueIndexes,
@@ -303,6 +329,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             collection,
             key,
             createdAt: existing.createdAt,
+            writeVersion: existing.writeVersion + 1,
             doc,
             indexes,
             uniqueIndexes,
@@ -352,6 +379,16 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       return paginateQuery(collection, matched, params);
     },
 
+    async queryWithMetadata(collection, params) {
+      const db = await dbPromise;
+      const records =
+        (await listCollectionDocumentsByIndex(db, collection, params)) ??
+        (await listCollectionDocuments(db, collection));
+      const matched = matchDocuments(records, params);
+
+      return paginateQuery(collection, matched, params, true);
+    },
+
     async batchGet(collection, keys) {
       const db = await dbPromise;
 
@@ -368,6 +405,32 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
           const record = parseStoredDocumentRecord(raw);
           results.push({ key, doc: structuredClone(record.doc) });
+        }
+
+        return results;
+      });
+    },
+
+    async batchGetWithMetadata(collection, keys) {
+      const db = await dbPromise;
+
+      return withTransaction(db, [STORE_DOCUMENTS], "readonly", async (tx) => {
+        const docsStore = tx.objectStore(STORE_DOCUMENTS);
+        const results: KeyedDocument[] = [];
+
+        for (const key of keys) {
+          const raw = await requestToPromise(docsStore.get(makeDocumentId(collection, key)));
+
+          if (raw === undefined) {
+            continue;
+          }
+
+          const record = parseStoredDocumentRecord(raw);
+          results.push({
+            key,
+            doc: structuredClone(record.doc),
+            writeToken: String(record.writeVersion),
+          });
         }
 
         return results;
@@ -398,15 +461,18 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             const existingRaw = await requestToPromise(docsStore.get(docId));
 
             let createdAt: number;
+            let writeVersion: number;
             let existingIndexes: ResolvedIndexKeys = {};
 
             if (existingRaw === undefined) {
               sequence += 1;
               sequenceChanged = true;
               createdAt = sequence;
+              writeVersion = 1;
             } else {
               const existing = parseStoredDocumentRecord(existingRaw);
               createdAt = existing.createdAt;
+              writeVersion = existing.writeVersion + 1;
               existingIndexes = existing.indexes;
             }
 
@@ -419,6 +485,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
               collection,
               key: item.key,
               createdAt,
+              writeVersion,
               doc: item.doc,
               indexes: item.indexes,
               uniqueIndexes,
@@ -438,6 +505,82 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
           if (sequenceChanged) {
             await saveSequence(metaStore, sequence);
           }
+        },
+      );
+    },
+
+    async batchSetWithResult(collection, items) {
+      const db = await dbPromise;
+
+      return withTransaction(
+        db,
+        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES],
+        "readwrite",
+        async (tx) => {
+          const docsStore = tx.objectStore(STORE_DOCUMENTS);
+          const metaStore = tx.objectStore(STORE_META);
+          const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
+          const collectionRecords = await loadCollectionRecordsFromStore(docsStore, collection);
+          const recordsByKey = new Map(
+            collectionRecords.map((record) => [record.key, record] as const),
+          );
+          const persistedKeys: string[] = [];
+          const conflictedKeys: string[] = [];
+
+          let sequence = await loadSequence(metaStore);
+          let sequenceChanged = false;
+
+          for (const item of items) {
+            const existing = recordsByKey.get(item.key);
+
+            if (
+              item.expectedWriteToken !== undefined &&
+              String(existing?.writeVersion) !== item.expectedWriteToken
+            ) {
+              conflictedKeys.push(item.key);
+              continue;
+            }
+
+            const docId = makeDocumentId(collection, item.key);
+            const createdAt = existing?.createdAt ?? sequence + 1;
+
+            if (!existing) {
+              sequence = createdAt;
+              sequenceChanged = true;
+            }
+
+            const uniqueIndexes = item.uniqueIndexes ?? {};
+
+            assertUniqueIndexes(collection, item.key, uniqueIndexes, [...recordsByKey.values()]);
+
+            const storedRecord = createStoredDocumentRecord({
+              id: docId,
+              collection,
+              key: item.key,
+              createdAt,
+              writeVersion: (existing?.writeVersion ?? 0) + 1,
+              doc: item.doc,
+              indexes: item.indexes,
+              uniqueIndexes,
+            });
+
+            await requestToPromise(docsStore.put(storedRecord));
+            await replaceQueryIndexEntries(
+              indexStore,
+              collection,
+              item.key,
+              existing?.indexes ?? {},
+              item.indexes,
+            );
+            recordsByKey.set(item.key, storedRecord);
+            persistedKeys.push(item.key);
+          }
+
+          if (sequenceChanged) {
+            await saveSequence(metaStore, sequence);
+          }
+
+          return { persistedKeys, conflictedKeys };
         },
       );
     },
@@ -877,6 +1020,7 @@ function paginate(records: StoredDocumentRecord[], params: QueryParams): EngineQ
     documents: page.map((record) => ({
       key: record.key,
       doc: structuredClone(record.doc),
+      writeToken: String(record.writeVersion),
     })),
     cursor,
   };
@@ -886,6 +1030,7 @@ function paginateQuery(
   collection: string,
   records: StoredDocumentRecord[],
   params: QueryParams,
+  includeMetadata = false,
 ): EngineQueryResult {
   const startIndex = resolveQueryPageStartIndex(
     records,
@@ -921,10 +1066,19 @@ function paginateQuery(
       : null;
 
   return {
-    documents: page.map((record) => ({
-      key: record.key,
-      doc: structuredClone(record.doc),
-    })),
+    documents: page.map((record) => {
+      const document = {
+        key: record.key,
+        doc: structuredClone(record.doc),
+      };
+
+      return includeMetadata
+        ? {
+            ...document,
+            writeToken: String(record.writeVersion),
+          }
+        : document;
+    }),
     cursor,
   };
 }
@@ -1303,6 +1457,7 @@ function createStoredDocumentRecord(input: {
   collection: string;
   key: string;
   createdAt: number;
+  writeVersion: number;
   doc: unknown;
   indexes: ResolvedIndexKeys;
   uniqueIndexes?: ResolvedIndexKeys;
@@ -1312,6 +1467,7 @@ function createStoredDocumentRecord(input: {
     collection: input.collection,
     key: input.key,
     createdAt: input.createdAt,
+    writeVersion: input.writeVersion,
     doc: getPreparedClone(input.doc) ?? (structuredClone(input.doc) as Record<string, unknown>),
     indexes: { ...input.indexes },
     uniqueIndexes: { ...input.uniqueIndexes },
@@ -1327,6 +1483,7 @@ function parseStoredDocumentRecord(value: unknown): StoredDocumentRecord {
   const collection = value.collection;
   const key = value.key;
   const createdAt = value.createdAt;
+  const writeVersion = value.writeVersion;
   const doc = value.doc;
   const indexes = value.indexes;
   const uniqueIndexes = value.uniqueIndexes;
@@ -1337,6 +1494,13 @@ function parseStoredDocumentRecord(value: unknown): StoredDocumentRecord {
 
   if (typeof createdAt !== "number" || !Number.isFinite(createdAt)) {
     throw new Error("IndexedDB documents store contains an invalid record (bad createdAt)");
+  }
+
+  if (
+    writeVersion !== undefined &&
+    (typeof writeVersion !== "number" || !Number.isFinite(writeVersion) || writeVersion < 1)
+  ) {
+    throw new Error("IndexedDB documents store contains an invalid record (bad writeVersion)");
   }
 
   if (!isRecord(doc)) {
@@ -1379,6 +1543,7 @@ function parseStoredDocumentRecord(value: unknown): StoredDocumentRecord {
     collection,
     key,
     createdAt,
+    writeVersion: writeVersion ?? 1,
     doc: doc as Record<string, unknown>,
     indexes: resolvedIndexes,
     uniqueIndexes: resolvedUniqueIndexes,

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { indexedDB as fakeIndexedDB } from "fake-indexeddb";
+import * as z from "zod";
 
 import { indexedDbEngine, type IndexedDbQueryEngine } from "../../src/engines/indexeddb";
 import {
@@ -7,9 +8,17 @@ import {
   EngineDocumentNotFoundError,
   EngineUniqueConstraintError,
   type ComparableVersion,
+  type QueryEngine,
 } from "../../src/engines/types";
+import { model } from "../../src/model";
+import { ConcurrentWriteError, createStore } from "../../src/store";
 import { runQueryEngineConformanceSuite } from "./conformance-suite";
-import { createCollectionNameFactory, createTestResourceName, expectReject } from "./helpers";
+import {
+  createCollectionNameFactory,
+  createTestResourceName,
+  expectReject,
+  expectRejectInstanceOf,
+} from "./helpers";
 import { runMigrationIntegrationSuite } from "./migration-suite";
 
 let engine: IndexedDbQueryEngine;
@@ -308,6 +317,71 @@ describe("indexedDbEngine basic CRUD", () => {
     expect(await engine.get("users", "u1")).toEqual({
       id: "u1",
       name: "Samuel",
+    });
+  });
+
+  test("metadata reads expose changing write tokens", async () => {
+    await engine.put("users", "u1", { id: "u1", name: "Sam" }, { primary: "u1" });
+
+    const first = await engine.getWithMetadata!("users", "u1");
+
+    await engine.update("users", "u1", { id: "u1", name: "Samuel" }, { primary: "u1" });
+
+    const second = await engine.getWithMetadata!("users", "u1");
+
+    expect(first?.writeToken).toBe("1");
+    expect(second?.writeToken).toBe("2");
+    expect(second?.doc).toEqual({ id: "u1", name: "Samuel" });
+  });
+
+  test("store.update throws ConcurrentWriteError when an IndexedDB document changes after read", async () => {
+    const User = model("user")
+      .schema(
+        1,
+        z.object({
+          id: z.string(),
+          name: z.string(),
+          email: z.email(),
+        }),
+      )
+      .index({ name: "primary", value: "id" })
+      .build();
+    const conflictingEngine: QueryEngine = {
+      ...engine,
+      async getWithMetadata(collection, key) {
+        const result = await engine.getWithMetadata!(collection, key);
+
+        if (key === "u1") {
+          await engine.update(
+            collection,
+            key,
+            {
+              __v: 1,
+              __indexes: ["primary"],
+              id: "u1",
+              name: "Concurrent",
+              email: "sam@example.com",
+            },
+            { primary: "u1" },
+          );
+        }
+
+        return result;
+      },
+    };
+    const store = createStore(conflictingEngine, [User]);
+
+    await store.user.create("u1", {
+      id: "u1",
+      name: "Sam",
+      email: "sam@example.com",
+    });
+
+    await expectRejectInstanceOf(store.user.update("u1", { name: "Samuel" }), ConcurrentWriteError);
+    expect(await store.user.findByKey("u1")).toEqual({
+      id: "u1",
+      name: "Concurrent",
+      email: "sam@example.com",
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #155.

Adds optimistic write-token support to the IndexedDB adapter so it matches the durable adapters that already protect store updates and lazy migration writebacks from stale writes.

## Changes

- Add a `writeVersion` field to IndexedDB document records and increment it on `put`, `update`, `batchSet`, and conditional batch writes.
- Implement `getWithMetadata`, `queryWithMetadata`, `batchGetWithMetadata`, and `batchSetWithResult` for IndexedDB.
- Make `batchSetWithResult` report stale `expectedWriteToken` mismatches in `conflictedKeys` before running unique-index validation for that item.
- Return write tokens from migration/outdated reads so lazy and eager migration writebacks can use conditional writes.
- Add IndexedDB integration coverage for changing metadata tokens, concurrent `store.update()` conflict handling, and the shared stale-token conformance cases.
- Include a patch changeset.

## Root Cause

IndexedDB records did not track a storage-level write token, so the store could not pass `expectedWriteToken` through its conflict-protection path. Reads and migration scans therefore used unconditional writebacks, allowing changes made between read and write phases to be overwritten.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run lint`
- `bun run test`
- `bun run test:integration:indexeddb`
- `bun run typecheck`

Note: the worktree still has a pre-existing untracked `examples/` directory that is not part of this PR.