### PR TITLE
[codex] Queue IndexedDB document reads

### DIFF
--- a/.changeset/quiet-rivers-fetch.md
+++ b/.changeset/quiet-rivers-fetch.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Queue IndexedDB batch and index-query document reads before awaiting results to reduce per-key read latency while preserving duplicate keys and request order.

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -144,6 +144,11 @@ interface MigrationCheckpointRecord {
   cursor: string;
 }
 
+interface LoadedDocumentRecord {
+  readonly key: string;
+  readonly record: StoredDocumentRecord | null;
+}
+
 // ---------------------------------------------------------------------------
 // Engine implementation
 // ---------------------------------------------------------------------------
@@ -395,16 +400,14 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       return withTransaction(db, [STORE_DOCUMENTS], "readonly", async (tx) => {
         const docsStore = tx.objectStore(STORE_DOCUMENTS);
         const results: KeyedDocument[] = [];
+        const records = await loadDocumentsByKeysFromStore(docsStore, collection, keys);
 
-        for (const key of keys) {
-          const raw = await requestToPromise(docsStore.get(makeDocumentId(collection, key)));
-
-          if (raw === undefined) {
+        for (const entry of records) {
+          if (entry.record === null) {
             continue;
           }
 
-          const record = parseStoredDocumentRecord(raw);
-          results.push({ key, doc: structuredClone(record.doc) });
+          results.push({ key: entry.key, doc: structuredClone(entry.record.doc) });
         }
 
         return results;
@@ -417,19 +420,17 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       return withTransaction(db, [STORE_DOCUMENTS], "readonly", async (tx) => {
         const docsStore = tx.objectStore(STORE_DOCUMENTS);
         const results: KeyedDocument[] = [];
+        const records = await loadDocumentsByKeysFromStore(docsStore, collection, keys);
 
-        for (const key of keys) {
-          const raw = await requestToPromise(docsStore.get(makeDocumentId(collection, key)));
-
-          if (raw === undefined) {
+        for (const entry of records) {
+          if (entry.record === null) {
             continue;
           }
 
-          const record = parseStoredDocumentRecord(raw);
           results.push({
-            key,
-            doc: structuredClone(record.doc),
-            writeToken: String(record.writeVersion),
+            key: entry.key,
+            doc: structuredClone(entry.record.doc),
+            writeToken: String(entry.record.writeVersion),
           });
         }
 
@@ -820,6 +821,25 @@ async function loadCollectionRecordsFromStore(
   return records;
 }
 
+async function loadDocumentsByKeysFromStore(
+  docsStore: IndexedDbObjectStoreLike,
+  collection: string,
+  keys: readonly string[],
+): Promise<LoadedDocumentRecord[]> {
+  const requests = keys.map((key) =>
+    requestToPromise(docsStore.get(makeDocumentId(collection, key))).then((raw) => ({
+      key,
+      raw,
+    })),
+  );
+  const rawEntries = await Promise.all(requests);
+
+  return rawEntries.map((entry) => ({
+    key: entry.key,
+    record: entry.raw === undefined ? null : parseStoredDocumentRecord(entry.raw),
+  }));
+}
+
 async function listCollectionDocumentsByIndex(
   db: IndexedDbDatabaseLike,
   collection: string,
@@ -848,17 +868,15 @@ async function listCollectionDocumentsByIndex(
         params.index!,
         equalityValue,
       );
-      const records: StoredDocumentRecord[] = [];
-
-      for (const entry of entries) {
-        const raw = await requestToPromise(docsStore.get(makeDocumentId(collection, entry.key)));
-
-        if (raw === undefined) {
-          continue;
-        }
-
-        records.push(parseStoredDocumentRecord(raw));
-      }
+      const records = (
+        await loadDocumentsByKeysFromStore(
+          docsStore,
+          collection,
+          entries.map((entry) => entry.key),
+        )
+      )
+        .map((entry) => entry.record)
+        .filter((record) => record !== null);
 
       records.sort((a, b) => {
         if (a.createdAt !== b.createdAt) {

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -41,6 +41,7 @@ interface RawOpenRequest<TDatabase> extends RawRequest<TDatabase> {
 }
 
 interface RawObjectStore {
+  get(key: string): RawRequest<unknown>;
   getAll(): RawRequest<unknown[]>;
   put(value: unknown): RawRequest<unknown>;
 }
@@ -173,6 +174,131 @@ function createDocumentGetAllGuardFactory() {
     },
     blockQueryIndexEntriesGetAll() {
       blockQueryIndexEntriesGetAll = true;
+    },
+  };
+}
+
+function createDocumentGetQueueAssertionFactory(expectedGetCount: number) {
+  let documentGetCount = 0;
+  let assertGetCount = false;
+
+  const wrapRequest = (request: unknown): unknown => {
+    return new Proxy(request as Record<string, unknown>, {
+      get(target, property, receiver) {
+        return Reflect.get(target, property, receiver);
+      },
+      set(target, property, value, receiver) {
+        if (property !== "onsuccess" || typeof value !== "function") {
+          return Reflect.set(target, property, value, receiver);
+        }
+
+        const wrappedHandler = (event: unknown) => {
+          if (assertGetCount) {
+            expect(documentGetCount).toBe(expectedGetCount);
+          }
+
+          value(event);
+        };
+
+        return Reflect.set(target, property, wrappedHandler, receiver);
+      },
+    });
+  };
+
+  const wrapObjectStore = (storeName: string, store: unknown): unknown => {
+    if (storeName !== RAW_STORE_DOCUMENTS) {
+      return store;
+    }
+
+    return new Proxy(store as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "get") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (key: string) => {
+          documentGetCount += 1;
+
+          return wrapRequest(
+            (Reflect.get(target, property, receiver) as (documentKey: string) => unknown).call(
+              target,
+              key,
+            ),
+          );
+        };
+      },
+    });
+  };
+
+  const wrapTransaction = (transaction: unknown): unknown => {
+    return new Proxy(transaction as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "objectStore") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (storeName: string) => {
+          const objectStore = (
+            Reflect.get(target, property, receiver) as (name: string) => unknown
+          ).call(target, storeName);
+
+          return wrapObjectStore(storeName, objectStore);
+        };
+      },
+    });
+  };
+
+  const wrapDatabase = (database: unknown): unknown => {
+    return new Proxy(database as Record<string, unknown>, {
+      get(target, property, receiver) {
+        if (property !== "transaction") {
+          return Reflect.get(target, property, receiver);
+        }
+
+        return (storeNames: string | string[], mode?: "readonly" | "readwrite") => {
+          const transaction = (
+            Reflect.get(target, property, receiver) as (
+              names: string | string[],
+              mode?: "readonly" | "readwrite",
+            ) => unknown
+          ).call(target, storeNames, mode);
+
+          return wrapTransaction(transaction);
+        };
+      },
+    });
+  };
+
+  const factory = {
+    open(name: string, version?: number) {
+      const request = (fakeIndexedDB as unknown as IndexedDbFactory).open(name, version);
+
+      return new Proxy(request as unknown as Record<string, unknown>, {
+        get(target, property, receiver) {
+          if (property === "result") {
+            return wrapDatabase(Reflect.get(target, property, receiver));
+          }
+
+          return Reflect.get(target, property, receiver);
+        },
+        set(target, property, value, receiver) {
+          return Reflect.set(target, property, value, receiver);
+        },
+      }) as unknown as ReturnType<IndexedDbFactory["open"]>;
+    },
+    deleteDatabase(name: string) {
+      return (fakeIndexedDB as unknown as IndexedDbFactory).deleteDatabase(name);
+    },
+  } satisfies IndexedDbFactory;
+
+  return {
+    factory,
+    startAssertion() {
+      documentGetCount = 0;
+      assertGetCount = true;
+    },
+    get documentGetCount() {
+      return documentGetCount;
     },
   };
 }
@@ -489,6 +615,32 @@ describe("indexedDbEngine batch methods", () => {
     expect(docs[0]!.doc).not.toBe(docs[1]!.doc);
   });
 
+  test("batchGet queues document reads before awaiting request results", async () => {
+    const asserted = createDocumentGetQueueAssertionFactory(4);
+    const indexedEngine = indexedDbEngine({
+      databaseName: `${databaseNameBase}_batch_get_queue_${Date.now()}`,
+      factory: asserted.factory,
+    });
+
+    try {
+      await indexedEngine.batchSet("users", [
+        { key: "u1", doc: { id: "u1", name: "A" }, indexes: { primary: "u1" } },
+        { key: "u2", doc: { id: "u2", name: "B" }, indexes: { primary: "u2" } },
+      ]);
+
+      asserted.startAssertion();
+      const docs = await indexedEngine.batchGet("users", ["u2", "u1", "u2", "missing"]);
+
+      expect(asserted.documentGetCount).toBe(4);
+      expect(docs.map((entry) => entry.key)).toEqual(["u2", "u1", "u2"]);
+      expect(docs[0]?.doc).toEqual({ id: "u2", name: "B" });
+      expect(docs[1]?.doc).toEqual({ id: "u1", name: "A" });
+      expect(docs[2]?.doc).toEqual({ id: "u2", name: "B" });
+    } finally {
+      await indexedEngine.deleteDatabase();
+    }
+  });
+
   test("batchSet enforces every unique index field atomically", async () => {
     try {
       await engine.batchSet!("users", [
@@ -546,6 +698,31 @@ describe("indexedDbEngine query behavior", () => {
       });
 
       expect(results.documents).toEqual([{ key: "u1", doc: { id: "u1" } }]);
+    } finally {
+      await indexedEngine.deleteDatabase();
+    }
+  });
+
+  test("query with index equality queues hydration reads before awaiting request results", async () => {
+    const asserted = createDocumentGetQueueAssertionFactory(2);
+    const indexedEngine = indexedDbEngine({
+      databaseName: `${databaseNameBase}_query_hydration_queue_${Date.now()}`,
+      factory: asserted.factory,
+    });
+
+    try {
+      await indexedEngine.put("users", "u1", { id: "u1", name: "A" }, { status: "active" });
+      await indexedEngine.put("users", "u2", { id: "u2", name: "B" }, { status: "active" });
+      await indexedEngine.put("users", "u3", { id: "u3", name: "C" }, { status: "inactive" });
+
+      asserted.startAssertion();
+      const results = await indexedEngine.query("users", {
+        index: "status",
+        filter: { value: "active" },
+      });
+
+      expect(asserted.documentGetCount).toBe(2);
+      expect(results.documents.map((entry) => entry.key)).toEqual(["u1", "u2"]);
     } finally {
       await indexedEngine.deleteDatabase();
     }

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -641,6 +641,40 @@ describe("indexedDbEngine batch methods", () => {
     }
   });
 
+  test("batchGetWithMetadata queues document reads before awaiting request results", async () => {
+    const asserted = createDocumentGetQueueAssertionFactory(4);
+    const indexedEngine = indexedDbEngine({
+      databaseName: `${databaseNameBase}_batch_get_metadata_queue_${Date.now()}`,
+      factory: asserted.factory,
+    });
+
+    try {
+      await indexedEngine.batchSet("users", [
+        { key: "u1", doc: { id: "u1", name: "A" }, indexes: { primary: "u1" } },
+        { key: "u2", doc: { id: "u2", name: "B" }, indexes: { primary: "u2" } },
+      ]);
+
+      asserted.startAssertion();
+      const docs = await indexedEngine.batchGetWithMetadata!("users", [
+        "u2",
+        "u1",
+        "u2",
+        "missing",
+      ]);
+
+      expect(asserted.documentGetCount).toBe(4);
+      expect(docs.map((entry) => entry.key)).toEqual(["u2", "u1", "u2"]);
+      expect(docs[0]?.doc).toEqual({ id: "u2", name: "B" });
+      expect(docs[0]?.writeToken).toBe("1");
+      expect(docs[1]?.doc).toEqual({ id: "u1", name: "A" });
+      expect(docs[1]?.writeToken).toBe("1");
+      expect(docs[2]?.doc).toEqual({ id: "u2", name: "B" });
+      expect(docs[2]?.writeToken).toBe("1");
+    } finally {
+      await indexedEngine.deleteDatabase();
+    }
+  });
+
   test("batchSet enforces every unique index field atomically", async () => {
     try {
       await engine.batchSet!("users", [


### PR DESCRIPTION
## Summary

Queues IndexedDB document `get()` requests for `batchGet`, `batchGetWithMetadata`, and equality-index query hydration before awaiting request results.

## Why

Fixes #156. These paths previously awaited each document read one at a time inside the transaction, adding avoidable per-key latency for large batches and indexed equality queries. Browsers can queue multiple IndexedDB requests in the same transaction, so the reads should be scheduled together while preserving the existing output semantics.

## Impact

- `batchGet` and `batchGetWithMetadata` still preserve request order, duplicate keys, and missing-document filtering.
- Indexed equality-query hydration now batches document reads after loading matching index entries.
- Added regression coverage that fails if the first document read resolves before all expected reads are queued.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun run test:integration:indexeddb`