### PR TITLE
[codex] Cover migration telemetry page average calculation

### DIFF
--- a/.changeset/steady-pages-smile.md
+++ b/.changeset/steady-pages-smile.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Add regression coverage for migration telemetry average page duration calculations.

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -278,6 +278,7 @@ describe("paged migration API", () => {
     expect(userProgress).toBeDefined();
     const userTelemetry = userProgress!.telemetry;
     expect(userTelemetry.totalDurationMs).toBeGreaterThanOrEqual(15);
+    expect(userTelemetry.averagePageDurationMs).toBe(firstTelemetry.durationMs);
     expect(userTelemetry.recordsPerSecond).toBeGreaterThan(0);
     expect(userTelemetry.writebackFailures).toBe(0);
     expect(userTelemetry.recentPages).toHaveLength(1);
@@ -309,6 +310,9 @@ describe("paged migration API", () => {
     const completedTelemetry = completedUserProgress!.telemetry;
     expect(completedTelemetry.totalDurationMs).toBeGreaterThanOrEqual(
       firstTelemetry.durationMs + secondTelemetry.durationMs,
+    );
+    expect(completedTelemetry.averagePageDurationMs).toBe(
+      Number(((firstTelemetry.durationMs + secondTelemetry.durationMs) / 2).toFixed(2)),
     );
     expect(completedTelemetry.recordsPerSecond).toBeGreaterThan(0);
     expect(completedTelemetry.writebackFailures).toBe(0);

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -278,7 +278,9 @@ describe("paged migration API", () => {
     expect(userProgress).toBeDefined();
     const userTelemetry = userProgress!.telemetry;
     expect(userTelemetry.totalDurationMs).toBeGreaterThanOrEqual(15);
-    expect(userTelemetry.averagePageDurationMs).toBe(firstTelemetry.durationMs);
+    expect(userTelemetry.averagePageDurationMs).toBe(
+      Number((firstTelemetry.durationMs / 1).toFixed(2)),
+    );
     expect(userTelemetry.recordsPerSecond).toBeGreaterThan(0);
     expect(userTelemetry.writebackFailures).toBe(0);
     expect(userTelemetry.recentPages).toHaveLength(1);


### PR DESCRIPTION
## Summary

Adds regression coverage for Issue #159 so migration progress telemetry verifies `averagePageDurationMs` after both the first processed page and multiple processed pages.

## Details

The current migrator implementation already increments model page progress inside `migrateDocuments` before `recordPageTelemetry` records the aggregate telemetry. Because of that, the production code now satisfies the issue acceptance criteria. This PR adds explicit assertions to prevent the off-by-one denominator behavior from returning.

A patch changeset is included per repository convention.

Fixes #159.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

## Notes

I also started a broad `bun test` run, but stopped it after unrelated integration suites failed or timed out because local services were not running: MySQL at `127.0.0.1:3306`, Firestore, and Cassandra.