### PR TITLE
[codex] Fix migration persisted telemetry for void persists

### DIFF
--- a/.changeset/fresh-masks-report.md
+++ b/.changeset/fresh-masks-report.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Count migration persisted-record telemetry for engines whose migration persist path returns void after successful batch writes.

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -621,9 +621,6 @@ export class DefaultMigrator<TOptions = Record<string, unknown>> implements Migr
       if (normalized) {
         persistedKeys = new Set(normalized.persistedKeys);
         conflictedKeys = new Set(normalized.conflictedKeys);
-        persistedRecords = normalized.persistedKeys.filter(
-          (key) => !conflictedKeys.has(key),
-        ).length;
       }
 
       const attemptedKeys = writes.map((write) => write.key);
@@ -632,6 +629,7 @@ export class DefaultMigrator<TOptions = Record<string, unknown>> implements Migr
         ? attemptedKeys.filter((key) => persistedSet.has(key) && !conflictedKeys.has(key))
         : attemptedKeys.filter((key) => !conflictedKeys.has(key));
       const conflictedHookKeys = attemptedKeys.filter((key) => conflictedKeys.has(key));
+      persistedRecords = persistedHookKeys.length;
 
       await this.runHook("onDocumentsPersisted", {
         runId: run.id,

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -324,6 +324,63 @@ describe("paged migration API", () => {
       1,
     );
   });
+
+  test("migrateNextPage counts persisted records when persist returns void", async () => {
+    await seedUsers(engine, 101);
+    delete (engine as { batchSetWithResult?: unknown }).batchSetWithResult;
+
+    const store = createStore(engine, [buildUserV2()]);
+    const page = await store.user.migrateNextPage();
+
+    expect(page.status).toBe("processed");
+    expect(page.telemetry?.persistedRecords).toBe(100);
+    expect(page.progress?.progressByModel.user?.telemetry.persistedRecords).toBe(100);
+  });
+
+  test("migrateNextPage counts persisted and conflicted records from batch results", async () => {
+    await seedUsers(engine, 2);
+
+    const persistedEvents: Array<{
+      persistedKeys: readonly string[];
+      conflictedKeys: readonly string[];
+    }> = [];
+    engine.batchSetWithResult = async (_collection, items) => {
+      await engine.batchSet(
+        "user",
+        items.filter((item) => item.key === "u0000"),
+      );
+
+      return {
+        persistedKeys: ["u0000"],
+        conflictedKeys: ["u0001"],
+      };
+    };
+
+    const store = createStore(engine, [buildUserV2()], {
+      migrationHooks: {
+        onDocumentsPersisted(event) {
+          persistedEvents.push({
+            persistedKeys: event.persistedKeys,
+            conflictedKeys: event.conflictedKeys,
+          });
+        },
+      },
+    });
+    const page = await store.user.migrateNextPage();
+
+    expect(page.status).toBe("completed");
+    expect(page.migrated).toBe(1);
+    expect(page.skipped).toBe(1);
+    expect(page.telemetry?.persistedRecords).toBe(1);
+    expect(page.telemetry?.writebackFailures).toBe(1);
+    expect(page.skipReasons).toEqual({ concurrent_write: 1 });
+    expect(persistedEvents).toEqual([
+      {
+        persistedKeys: ["u0000"],
+        conflictedKeys: ["u0001"],
+      },
+    ]);
+  });
 });
 
 describe("migration progress", () => {


### PR DESCRIPTION
## Summary

Fixes #160.

Migration page telemetry now counts persisted records from the attempted non-conflicted write set when a migration `persist` implementation succeeds but returns `void`. Engines that return an explicit `BatchSetResult` keep using that result to distinguish persisted and conflicted keys, so partial conflict reporting remains accurate.

## Root Cause

`migrateDocuments` initialized `persistedRecords` to `0` and only updated it when `normalizeBatchSetResult(...)` returned a result. For engines that persist via plain `batchSet`, `context.persist(...)` can succeed with no return value, leaving telemetry at zero even though the hook path already treated attempted non-conflicted keys as persisted.

## Changes

- Derive `persistedRecords` from the same persisted key set used for `onDocumentsPersisted` hook payloads.
- Added regression coverage for void-returning persist implementations.
- Added coverage that explicit `BatchSetResult` handling still reports persisted records, conflicts, writeback failures, and hook payloads correctly.
- Added a patch changeset.

## Validation

- `bun test tests/unit/migrator.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`