### PR TITLE
[codex] Emit final migration page commit hook

### DIFF
--- a/.changeset/final-pages-commit.md
+++ b/.changeset/final-pages-commit.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Emit `onPageCommitted` for the final migration page before `onMigrationCompleted`.

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -463,8 +463,17 @@ export class DefaultMigrator<TOptions = Record<string, unknown>> implements Migr
         const completed = run.modelIndex >= run.models.length;
 
         if (completed) {
-          await this.engine.migration.clearCheckpoint?.(runKey);
           const completedProgress = toProgress(run, false);
+          await this.runHook("onPageCommitted", {
+            runId: run.id,
+            model: modelName,
+            migrated: result.migrated,
+            skipped: result.skipped,
+            cursor: run.cursor,
+            hasMore: false,
+            telemetry: pageTelemetry,
+          });
+          await this.engine.migration.clearCheckpoint?.(runKey);
           await this.runHook("onMigrationCompleted", { progress: completedProgress });
 
           return {

--- a/tests/unit/migrator.test.ts
+++ b/tests/unit/migrator.test.ts
@@ -235,6 +235,7 @@ describe("paged migration API", () => {
 
     const pageCommittedEvents: Array<{
       model: string;
+      hasMore: boolean;
       telemetry: {
         durationMs: number;
         recordsPerSecond: number;
@@ -243,12 +244,15 @@ describe("paged migration API", () => {
       };
     }> = [];
     let completedProgress: MigrationRunProgress | null = null;
+    const hookOrder: string[] = [];
 
     const store = createStore(engine, [buildUserV2()], {
       migrationHooks: {
         onPageCommitted(event) {
+          hookOrder.push(`page:${event.hasMore ? "more" : "final"}`);
           pageCommittedEvents.push({
             model: event.model,
+            hasMore: event.hasMore,
             telemetry: {
               durationMs: event.telemetry.durationMs,
               recordsPerSecond: event.telemetry.recordsPerSecond,
@@ -258,6 +262,7 @@ describe("paged migration API", () => {
           });
         },
         onMigrationCompleted(event) {
+          hookOrder.push("completed");
           completedProgress = event.progress;
         },
       },
@@ -295,16 +300,29 @@ describe("paged migration API", () => {
     expect(secondTelemetry.durationMs).toBeGreaterThanOrEqual(15);
     expect(secondTelemetry.skipReasons.validation_error).toBeGreaterThanOrEqual(1);
 
-    expect(pageCommittedEvents).toHaveLength(1);
-    expect(pageCommittedEvents[0]).toEqual({
-      model: "user",
-      telemetry: {
-        durationMs: firstTelemetry.durationMs,
-        recordsPerSecond: firstTelemetry.recordsPerSecond,
-        writebackFailures: 0,
-        skipReasons: { validation_error: 1 },
+    expect(pageCommittedEvents).toEqual([
+      {
+        model: "user",
+        hasMore: true,
+        telemetry: {
+          durationMs: firstTelemetry.durationMs,
+          recordsPerSecond: firstTelemetry.recordsPerSecond,
+          writebackFailures: 0,
+          skipReasons: { validation_error: 1 },
+        },
       },
-    });
+      {
+        model: "user",
+        hasMore: false,
+        telemetry: {
+          durationMs: secondTelemetry.durationMs,
+          recordsPerSecond: secondTelemetry.recordsPerSecond,
+          writebackFailures: 0,
+          skipReasons: secondTelemetry.skipReasons,
+        },
+      },
+    ]);
+    expect(hookOrder).toEqual(["page:more", "page:final", "completed"]);
 
     expect(completedProgress).not.toBeNull();
     const completedUserProgress = completedProgress!.progressByModel.user;


### PR DESCRIPTION
## Summary

Fixes #161 by emitting `onPageCommitted` for the page that completes a migration run before emitting `onMigrationCompleted`.

## Root Cause

`DefaultMigrator.migrateNextPage` only emitted `onPageCommitted` in the non-completed branch. When a processed page advanced the run past the final model, the method cleared the checkpoint and emitted `onMigrationCompleted` immediately, so hook observers missed the final page despite the method returning its telemetry.

## Changes

- Emit `onPageCommitted` in the completed branch with `hasMore: false` and the final cursor state.
- Preserve the existing `onMigrationCompleted` behavior and order it after the final page commit hook.
- Extend the migrator telemetry regression test to assert both page commit events and hook ordering.
- Add a patch changeset for the bug fix.

## Validation

- `bun test ./tests/unit/migrator.test.ts`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`
- `git diff --check`