### PR TITLE
[codex] Fix neutral build warnings for node:crypto imports

### DIFF
--- a/.changeset/slow-kings-build.md
+++ b/.changeset/slow-kings-build.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Externalize Node built-ins during neutral builds so Node-only engine entries no longer emit unresolved import warnings.

--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -15,6 +15,7 @@ export default defineConfig({
     "./src/engines/mysql.ts",
     "./src/engines/postgres.ts",
   ],
+  external: [/^node:/],
   format: ["cjs", "esm"],
   platform: "neutral",
   outputOptions: {


### PR DESCRIPTION
## Summary

Closes #162.

This PR updates the tsdown build config to explicitly externalize `node:` specifiers while keeping the existing neutral platform build. That lets Node-only engine entries such as MySQL and Firestore retain their `node:crypto` runtime imports without tsdown reporting unresolved import warnings.

A patch changeset is included for the packaging-facing build fix.

## Impact

Node/Bun consumers of the MySQL and Firestore adapters continue to resolve Node built-ins at runtime. Browser-safe entries such as memory and IndexedDB are not changed or forced to depend on Node built-ins.

## Validation

- `bun run build`
- `bun run fmt`
- `bun run lint:fix`
- `bun run test`
- `bun run typecheck`