### PR TITLE
[codex] Run production build in PR quality checks

### DIFF
--- a/.changeset/proud-builds-check.md
+++ b/.changeset/proud-builds-check.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Run the production build in the PR quality workflow so packaging and declaration generation failures block merges.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Run type check
         run: bun typecheck
+
+      - name: Run production build
+        run: bun run build


### PR DESCRIPTION
## Summary

Adds the production package build to the pull request quality workflow so PRs run the same bundling and declaration-generation check that previously only ran during publish.

## Why

Issue #163 notes that lint, format, typecheck, and unit tests can pass while export-map drift, bundler warnings, declaration-generation failures, or packaging regressions remain undetected until the publish workflow. Running `bun run build` in the PR quality gate catches those failures before merge.

## Changes

- Run `bun run build` after `bun typecheck` in `.github/workflows/quality.yml`.
- Add a patch changeset documenting the CI quality-gate change.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test` (593 tests passed)
- `bun typecheck`
- `bun run build`

Note: an initial direct `bun test` invocation also picked up integration suites and failed because MySQL was not running locally. The repo unit-test script `bun run test` passed.

Closes #163