### PR TITLE
[codex] Reduce createdAt sequence contention

### DIFF
--- a/.changeset/tall-keys-share.md
+++ b/.changeset/tall-keys-share.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Reduce non-SQL adapter write contention by replacing per-collection createdAt sequence reservations with time-sortable local allocation while preserving deterministic cursor tie-breaking.

--- a/src/engines/distributed-created-at.ts
+++ b/src/engines/distributed-created-at.ts
@@ -1,0 +1,38 @@
+const CREATED_AT_SEQUENCE_LIMIT = 1000;
+
+const state = {
+  lastTimestamp: 0,
+  sequence: 0,
+};
+
+export function nextCreatedAt(): number {
+  const now = Date.now();
+
+  if (now > state.lastTimestamp) {
+    state.lastTimestamp = now;
+    state.sequence = 0;
+
+    return toCreatedAtValue(state.lastTimestamp, state.sequence);
+  }
+
+  if (state.sequence < CREATED_AT_SEQUENCE_LIMIT - 1) {
+    state.sequence += 1;
+  } else {
+    state.lastTimestamp += 1;
+    state.sequence = 0;
+  }
+
+  return toCreatedAtValue(state.lastTimestamp, state.sequence);
+}
+
+export function reserveCreatedAtRange(count: number): number[] {
+  if (!Number.isInteger(count) || count <= 0) {
+    return [];
+  }
+
+  return Array.from({ length: count }, () => nextCreatedAt());
+}
+
+function toCreatedAtValue(timestamp: number, sequence: number): number {
+  return timestamp * CREATED_AT_SEQUENCE_LIMIT + sequence;
+}

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -6,7 +6,6 @@ import {
   PutCommand,
   QueryCommand,
   TransactWriteCommand,
-  UpdateCommand,
   type BatchGetCommandInput,
   type BatchWriteCommandInput,
   type QueryCommandInput,
@@ -14,6 +13,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 
 import { DefaultMigrator } from "../migrator";
+import { nextCreatedAt } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
 import {
@@ -275,7 +275,7 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
     },
 
     async create(collection, key, doc, indexes, _options, migrationMetadata) {
-      const createdAt = await nextSequence(client, tableName, keyConfig, collection);
+      const createdAt = nextCreatedAt();
       const item = createDocumentItem(collection, key, createdAt, 1, doc, indexes);
       const queryIndexItems = createQueryIndexItems(collection, key, createdAt, indexes);
       const metadata =
@@ -306,8 +306,7 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
 
     async put(collection, key, doc, indexes, _options, migrationMetadata) {
       const existing = await getDocumentItem(client, tableName, keyConfig, collection, key);
-      const createdAt =
-        existing?.createdAt ?? (await nextSequence(client, tableName, keyConfig, collection));
+      const createdAt = existing?.createdAt ?? nextCreatedAt();
       const writeVersion = (existing?.writeVersion ?? 0) + 1;
       const item = createDocumentItem(collection, key, createdAt, writeVersion, doc, indexes);
       const queryIndexItems = createQueryIndexItems(collection, key, createdAt, indexes);
@@ -448,9 +447,7 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
 
       for (const item of items) {
         const existingRecord = existing.get(item.key);
-        const createdAt =
-          existingRecord?.createdAt ??
-          (await nextSequence(client, tableName, keyConfig, collection));
+        const createdAt = existingRecord?.createdAt ?? nextCreatedAt();
         const writeVersion = (existingRecord?.writeVersion ?? 0) + 1;
         const metadata =
           normalizeMigrationMetadata(item.migrationMetadata) ??
@@ -535,9 +532,7 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
           continue;
         }
 
-        const createdAt =
-          existingRecord?.createdAt ??
-          (await nextSequence(client, tableName, keyConfig, collection));
+        const createdAt = existingRecord?.createdAt ?? nextCreatedAt();
         const writeVersion = (existingRecord?.writeVersion ?? 0) + 1;
         const docItem = createDocumentItem(
           collection,
@@ -777,10 +772,6 @@ function lockSortKey(collection: string): string {
 
 function checkpointSortKey(collection: string): string {
   return `CHECKPOINT#${collection}`;
-}
-
-function sequenceSortKey(collection: string): string {
-  return `SEQUENCE#${collection}`;
 }
 
 function metadataSortKey(key: string): string {
@@ -1024,45 +1015,6 @@ function parseMigrationMetadataItem(
     migrationSyncPk,
     migrationSyncSk,
   };
-}
-
-async function nextSequence(
-  client: DynamoDbDocumentClientLike,
-  tableName: string,
-  keyConfig: DynamoKeyConfig,
-  collection: string,
-): Promise<number> {
-  const sk = sequenceSortKey(collection);
-
-  const response = (await client.send(
-    new UpdateCommand({
-      TableName: tableName,
-      Key: toDynamoPrimaryKey(keyConfig, META_PARTITION_KEY, sk),
-      UpdateExpression: "SET #itemType = :itemType, #value = if_not_exists(#value, :zero) + :inc",
-      ExpressionAttributeNames: {
-        "#itemType": "itemType",
-        "#value": "value",
-      },
-      ExpressionAttributeValues: {
-        ":itemType": "sequence",
-        ":zero": 0,
-        ":inc": 1,
-      },
-      ReturnValues: "UPDATED_NEW",
-    }),
-  )) as {
-    Attributes?: {
-      value?: unknown;
-    };
-  };
-
-  const value = response.Attributes?.value;
-
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error("DynamoDB returned an invalid sequence value");
-  }
-
-  return value;
 }
 
 function createDocumentItem(

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -127,10 +127,6 @@ interface UniqueOwnershipRecord {
   indexValue: string;
 }
 
-interface CreatedAtReservation {
-  value: number;
-}
-
 export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQueryEngine {
   const database = options.database;
   const documentsCollection = database.collection(
@@ -188,16 +184,12 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
           throw new EngineDocumentAlreadyExistsError(collection, key);
         }
 
-        const createdAtReservation = await reserveNextCreatedAt(
-          transaction,
-          metadataCollection,
-          collection,
-        );
+        const createdAt = nextCreatedAt();
         const resolved = resolveWriteMetadata(migrationMetadata, doc);
         const created = createStoredDocumentRecord(
           collection,
           key,
-          createdAtReservation.value,
+          createdAt,
           1,
           doc,
           indexes,
@@ -231,14 +223,7 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
         const existingRecord = existing.exists
           ? parseStoredDocumentRecord(snapshotData(existing, "document record"))
           : null;
-        const createdAtReservation = existingRecord
-          ? null
-          : await reserveNextCreatedAt(transaction, metadataCollection, collection);
-        const createdAt = existingRecord?.createdAt ?? createdAtReservation?.value;
-
-        if (createdAt === undefined) {
-          throw new Error("Missing Firestore createdAt reservation");
-        }
+        const createdAt = existingRecord?.createdAt ?? nextCreatedAt();
 
         const writeVersion = existingRecord ? existingRecord.writeVersion + 1 : 1;
         const updated = createStoredDocumentRecord(
@@ -379,14 +364,7 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
           const existingRecord = existing.exists
             ? parseStoredDocumentRecord(snapshotData(existing, "document record"))
             : null;
-          const createdAtReservation = existingRecord
-            ? null
-            : await reserveNextCreatedAt(transaction, metadataCollection, collection);
-          const createdAt = existingRecord?.createdAt ?? createdAtReservation?.value;
-
-          if (createdAt === undefined) {
-            throw new Error("Missing Firestore createdAt reservation");
-          }
+          const createdAt = existingRecord?.createdAt ?? nextCreatedAt();
 
           const writeVersion = existingRecord ? existingRecord.writeVersion + 1 : 1;
           const resolved = resolveWriteMetadata(item.migrationMetadata, item.doc);
@@ -459,14 +437,7 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
             return "persisted" as const;
           }
 
-          const createdAtReservation = existingRecord
-            ? null
-            : await reserveNextCreatedAt(transaction, metadataCollection, collection);
-          const createdAt = existingRecord?.createdAt ?? createdAtReservation?.value;
-
-          if (createdAt === undefined) {
-            throw new Error("Missing Firestore createdAt reservation");
-          }
+          const createdAt = existingRecord?.createdAt ?? nextCreatedAt();
 
           const writeVersion = existingRecord ? existingRecord.writeVersion + 1 : 1;
           const updated = createStoredDocumentRecord(
@@ -730,20 +701,6 @@ function encodeIdPart(value: string): string {
 
 function hashIndexValue(value: string): string {
   return createHash("sha256").update(value).digest("hex");
-}
-
-async function reserveNextCreatedAt(
-  transaction: FirestoreTransactionLike,
-  metadataCollection: FirestoreCollectionLike,
-  collection: string,
-): Promise<CreatedAtReservation> {
-  void transaction;
-  void metadataCollection;
-  void collection;
-
-  return {
-    value: nextCreatedAt(),
-  };
 }
 
 async function listCollectionDocuments(

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 
 import { DefaultMigrator } from "../migrator";
+import { nextCreatedAt } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import {
   encodeQueryPageCursor,
@@ -127,7 +128,6 @@ interface UniqueOwnershipRecord {
 }
 
 interface CreatedAtReservation {
-  ref: FirestoreDocumentReferenceLike;
   value: number;
 }
 
@@ -214,10 +214,6 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
           {},
           created.uniqueIndexes,
         );
-        transaction.set(
-          createdAtReservation.ref,
-          createSequenceRecord(collection, createdAtReservation.value),
-        );
         transaction.create(ref, created);
 
         return created;
@@ -265,12 +261,6 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
           existingRecord?.uniqueIndexes ?? {},
           updated.uniqueIndexes,
         );
-        if (createdAtReservation) {
-          transaction.set(
-            createdAtReservation.ref,
-            createSequenceRecord(collection, createdAtReservation.value),
-          );
-        }
         transaction.set(ref, updated);
       });
     },
@@ -420,12 +410,6 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
             existingRecord?.uniqueIndexes ?? {},
             updated.uniqueIndexes,
           );
-          if (createdAtReservation) {
-            transaction.set(
-              createdAtReservation.ref,
-              createSequenceRecord(collection, createdAtReservation.value),
-            );
-          }
           transaction.set(ref, updated);
         });
       }
@@ -504,12 +488,6 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
             existingRecord?.uniqueIndexes ?? {},
             updated.uniqueIndexes,
           );
-          if (createdAtReservation) {
-            transaction.set(
-              createdAtReservation.ref,
-              createSequenceRecord(collection, createdAtReservation.value),
-            );
-          }
           transaction.set(ref, updated);
           return "persisted" as const;
         });
@@ -746,10 +724,6 @@ function uniqueOwnershipDocId(collection: string, indexName: string, indexValue:
   return `unique:${encodeIdPart(collection)}:${encodeIdPart(indexName)}:${hashIndexValue(indexValue)}`;
 }
 
-function sequenceDocId(collection: string): string {
-  return `sequence:${encodeIdPart(collection)}`;
-}
-
 function encodeIdPart(value: string): string {
   return encodeURIComponent(value);
 }
@@ -763,30 +737,12 @@ async function reserveNextCreatedAt(
   metadataCollection: FirestoreCollectionLike,
   collection: string,
 ): Promise<CreatedAtReservation> {
-  const ref = metadataRef(metadataCollection, sequenceDocId(collection));
-  const raw = await transaction.get(ref);
-  const snapshot = parseDocumentSnapshot(raw, "sequence record");
-
-  const value = snapshot.exists
-    ? readFiniteNumber(
-        parseRecord(snapshotData(snapshot, "sequence record"), "sequence record"),
-        "value",
-        "sequence record",
-      )
-    : 0;
-  const next = value + 1;
+  void transaction;
+  void metadataCollection;
+  void collection;
 
   return {
-    ref,
-    value: next,
-  };
-}
-
-function createSequenceRecord(collection: string, value: number): Record<string, unknown> {
-  return {
-    kind: "sequence",
-    collection,
-    value,
+    value: nextCreatedAt(),
   };
 }
 

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -1,4 +1,5 @@
 import { DefaultMigrator } from "../migrator";
+import { nextCreatedAt, reserveCreatedAtRange } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
 import {
@@ -117,7 +118,6 @@ const STORE_UNIQUE_INDEX_ENTRIES = "unique_index_entries";
 
 const QUERY_INDEX_LOOKUP = "lookup";
 
-const META_SEQUENCE_KEY = "sequence";
 const META_QUERY_INDEX_BACKFILL_KEY = "queryIndexEntriesBackfilledV2";
 const META_UNIQUE_INDEX_BACKFILL_KEY = "uniqueIndexEntriesBackfilledV4";
 const OUTDATED_PAGE_LIMIT = 100;
@@ -165,10 +165,7 @@ interface IndexEntryRange {
 }
 
 interface MetaSequenceRecord {
-  key:
-    | typeof META_SEQUENCE_KEY
-    | typeof META_QUERY_INDEX_BACKFILL_KEY
-    | typeof META_UNIQUE_INDEX_BACKFILL_KEY;
+  key: typeof META_QUERY_INDEX_BACKFILL_KEY | typeof META_UNIQUE_INDEX_BACKFILL_KEY;
   value: number;
 }
 
@@ -259,11 +256,10 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       await withTransaction(
         db,
-        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
         "readwrite",
         async (tx) => {
           const docsStore = tx.objectStore(STORE_DOCUMENTS);
-          const metaStore = tx.objectStore(STORE_META);
           const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
           const uniqueIndexStore = tx.objectStore(STORE_UNIQUE_INDEX_ENTRIES);
 
@@ -275,13 +271,13 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
           await assertUniqueIndexes(uniqueIndexStore, collection, key, uniqueIndexes ?? {});
 
-          const sequence = (await loadSequence(metaStore)) + 1;
+          const createdAt = nextCreatedAt();
 
           const record = createStoredDocumentRecord({
             id: docId,
             collection,
             key,
-            createdAt: sequence,
+            createdAt,
             writeVersion: 1,
             doc,
             indexes,
@@ -289,7 +285,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
           });
 
           await requestToPromise(docsStore.put(record));
-          await replaceQueryIndexEntries(indexStore, collection, key, sequence, {}, indexes);
+          await replaceQueryIndexEntries(indexStore, collection, key, createdAt, {}, indexes);
           await replaceUniqueIndexEntries(
             uniqueIndexStore,
             collection,
@@ -297,8 +293,6 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             {},
             uniqueIndexes ?? {},
           );
-
-          await saveSequence(metaStore, sequence);
         },
       );
     },
@@ -309,11 +303,10 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       await withTransaction(
         db,
-        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
         "readwrite",
         async (tx) => {
           const docsStore = tx.objectStore(STORE_DOCUMENTS);
-          const metaStore = tx.objectStore(STORE_META);
           const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
           const uniqueIndexStore = tx.objectStore(STORE_UNIQUE_INDEX_ENTRIES);
 
@@ -325,9 +318,8 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
           let existingUniqueIndexes: ResolvedIndexKeys = {};
 
           if (existingRaw === undefined) {
-            createdAt = (await loadSequence(metaStore)) + 1;
+            createdAt = nextCreatedAt();
             writeVersion = 1;
-            await saveSequence(metaStore, createdAt);
           } else {
             const existing = parseStoredDocumentRecord(existingRaw);
             createdAt = existing.createdAt;
@@ -540,16 +532,14 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       await withTransaction(
         db,
-        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
         "readwrite",
         async (tx) => {
           const docsStore = tx.objectStore(STORE_DOCUMENTS);
-          const metaStore = tx.objectStore(STORE_META);
           const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
           const uniqueIndexStore = tx.objectStore(STORE_UNIQUE_INDEX_ENTRIES);
-
-          let sequence = await loadSequence(metaStore);
-          let sequenceChanged = false;
+          const createdAts = reserveCreatedAtRange(items.length);
+          let createdAtIndex = 0;
 
           for (const item of items) {
             const docId = makeDocumentId(collection, item.key);
@@ -561,9 +551,14 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             let existingUniqueIndexes: ResolvedIndexKeys = {};
 
             if (existingRaw === undefined) {
-              sequence += 1;
-              sequenceChanged = true;
-              createdAt = sequence;
+              const reservedCreatedAt = createdAts[createdAtIndex];
+              createdAtIndex += 1;
+
+              if (reservedCreatedAt === undefined) {
+                throw new Error("IndexedDB failed to allocate createdAt");
+              }
+
+              createdAt = reservedCreatedAt;
               writeVersion = 1;
             } else {
               const existing = parseStoredDocumentRecord(existingRaw);
@@ -605,10 +600,6 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
               uniqueIndexes,
             );
           }
-
-          if (sequenceChanged) {
-            await saveSequence(metaStore, sequence);
-          }
         },
       );
     },
@@ -618,18 +609,16 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       return withTransaction(
         db,
-        [STORE_DOCUMENTS, STORE_META, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
+        [STORE_DOCUMENTS, STORE_QUERY_INDEX_ENTRIES, STORE_UNIQUE_INDEX_ENTRIES],
         "readwrite",
         async (tx) => {
           const docsStore = tx.objectStore(STORE_DOCUMENTS);
-          const metaStore = tx.objectStore(STORE_META);
           const indexStore = tx.objectStore(STORE_QUERY_INDEX_ENTRIES);
           const uniqueIndexStore = tx.objectStore(STORE_UNIQUE_INDEX_ENTRIES);
           const persistedKeys: string[] = [];
           const conflictedKeys: string[] = [];
-
-          let sequence = await loadSequence(metaStore);
-          let sequenceChanged = false;
+          const createdAts = reserveCreatedAtRange(items.length);
+          let createdAtIndex = 0;
 
           for (const item of items) {
             const existingRaw = await requestToPromise(
@@ -647,11 +636,15 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
             }
 
             const docId = makeDocumentId(collection, item.key);
-            const createdAt = existing?.createdAt ?? sequence + 1;
+            const reservedCreatedAt = existing ? undefined : createdAts[createdAtIndex];
+            const createdAt = existing?.createdAt ?? reservedCreatedAt;
 
             if (!existing) {
-              sequence = createdAt;
-              sequenceChanged = true;
+              createdAtIndex += 1;
+            }
+
+            if (createdAt === undefined) {
+              throw new Error("IndexedDB failed to allocate createdAt");
             }
 
             const uniqueIndexes = item.uniqueIndexes ?? {};
@@ -686,10 +679,6 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
               uniqueIndexes,
             );
             persistedKeys.push(item.key);
-          }
-
-          if (sequenceChanged) {
-            await saveSequence(metaStore, sequence);
           }
 
           return { persistedKeys, conflictedKeys };
@@ -2043,32 +2032,6 @@ function parseMigrationCheckpointRecord(value: unknown): MigrationCheckpointReco
   }
 
   return { collection, cursor };
-}
-
-async function loadSequence(metaStore: IndexedDbObjectStoreLike): Promise<number> {
-  const raw = await requestToPromise(metaStore.get(META_SEQUENCE_KEY));
-
-  if (raw === undefined) {
-    return 0;
-  }
-
-  if (!isRecord(raw)) {
-    throw new Error("IndexedDB meta store contains an invalid sequence record");
-  }
-
-  const key = raw.key;
-  const value = raw.value;
-
-  if (key !== META_SEQUENCE_KEY || typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error("IndexedDB meta store contains an invalid sequence record");
-  }
-
-  return value;
-}
-
-async function saveSequence(metaStore: IndexedDbObjectStoreLike, value: number): Promise<void> {
-  const record: MetaSequenceRecord = { key: META_SEQUENCE_KEY, value };
-  await requestToPromise(metaStore.put(record));
 }
 
 function parseMetaFlagRecord(

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -1,4 +1,5 @@
 import { DefaultMigrator } from "../migrator";
+import { reserveCreatedAtRange as reserveDistributedCreatedAtRange } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import {
   encodeQueryPageCursor,
@@ -1014,11 +1015,14 @@ async function nextCreatedAt(
   metadataCollection: MongoCollectionLike,
   collection: string,
 ): Promise<number> {
-  const createdAts = await reserveCreatedAtRange(metadataCollection, collection, 1);
+  void metadataCollection;
+  void collection;
+
+  const createdAts = reserveDistributedCreatedAtRange(1);
   const createdAt = createdAts[0];
 
   if (createdAt === undefined) {
-    throw new Error("MongoDB returned an invalid sequence record");
+    throw new Error("MongoDB failed to allocate createdAt");
   }
 
   return createdAt;
@@ -1029,42 +1033,14 @@ async function reserveCreatedAtRange(
   collection: string,
   count: number,
 ): Promise<number[]> {
-  // Reserve one sequence value per attempted upsert to preserve legacy ordering behavior.
-  // Updates can leave gaps because createdAt is written only on insert via $setOnInsert.
+  void metadataCollection;
+  void collection;
+
   if (!Number.isInteger(count) || count <= 0) {
     return [];
   }
 
-  const raw = await metadataCollection.findOneAndUpdate(
-    {
-      collection,
-      kind: "sequence",
-    },
-    {
-      $setOnInsert: {
-        collection,
-        kind: "sequence",
-      },
-      $inc: {
-        value: count,
-      },
-    },
-    {
-      upsert: true,
-      returnDocument: "after",
-    },
-  );
-
-  const valueDoc = parseFindOneAndUpdateResult(raw, "sequence record");
-  const value = readFiniteNumber(valueDoc, "value", "sequence record");
-  const start = value - count + 1;
-  const createdAts: number[] = [];
-
-  for (let index = 0; index < count; index += 1) {
-    createdAts.push(start + index);
-  }
-
-  return createdAts;
+  return reserveDistributedCreatedAtRange(count);
 }
 
 async function listCollectionDocuments(
@@ -1901,39 +1877,6 @@ function parseLockRecord(raw: unknown): LockRecord {
 function parseCheckpointRecord(raw: unknown): string {
   const record = parseRecord(raw, "migration checkpoint record");
   return readString(record, "cursor", "migration checkpoint record");
-}
-
-function parseFindOneAndUpdateResult(raw: unknown, context: string): Record<string, unknown> {
-  const wrapped = parseFindOneAndUpdateWrappedValue(raw);
-
-  if (wrapped.found) {
-    return parseRecord(wrapped.value, context);
-  }
-
-  return parseRecord(raw, context);
-}
-
-type WrappedFindOneAndUpdateValue = { found: true; value: unknown } | { found: false };
-
-function parseFindOneAndUpdateWrappedValue(raw: unknown): WrappedFindOneAndUpdateValue {
-  if (!isRecord(raw)) {
-    return { found: false };
-  }
-
-  // MongoDB Node drivers prior to v6 return a ModifyResult wrapper that
-  // includes metadata fields like `ok` / `lastErrorObject` and a `value`.
-  if (!("ok" in raw) && !("lastErrorObject" in raw)) {
-    return { found: false };
-  }
-
-  if (!("value" in raw)) {
-    return { found: false };
-  }
-
-  return {
-    found: true,
-    value: raw.value,
-  };
 }
 
 function parseIndexes(raw: unknown): ResolvedIndexKeys {

--- a/src/engines/mongodb.ts
+++ b/src/engines/mongodb.ts
@@ -1,5 +1,5 @@
 import { DefaultMigrator } from "../migrator";
-import { reserveCreatedAtRange as reserveDistributedCreatedAtRange } from "./distributed-created-at";
+import { nextCreatedAt, reserveCreatedAtRange } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import {
   encodeQueryPageCursor,
@@ -235,7 +235,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
     async create(collection, key, doc, indexes, _options, migrationMetadata) {
       await ready;
 
-      const createdAt = await nextCreatedAt(metadataCollection, collection);
+      const createdAt = nextCreatedAt();
       const metadata =
         normalizeMigrationMetadata(migrationMetadata) ?? deriveLegacyMetadataFromDocument(doc);
       const record = createStoredDocumentRecord(
@@ -262,7 +262,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
     async put(collection, key, doc, indexes, _options, migrationMetadata) {
       await ready;
 
-      const createdAt = await nextCreatedAt(metadataCollection, collection);
+      const createdAt = nextCreatedAt();
       const normalizedDoc = normalizeDocument(doc);
       const normalizedIndexes = normalizeIndexes(indexes);
       const metadata =
@@ -575,11 +575,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
           metadata,
         };
       });
-      const createdAts = await reserveCreatedAtRange(
-        metadataCollection,
-        collection,
-        preparedItems.length,
-      );
+      const createdAts = reserveCreatedAtRange(preparedItems.length);
       const operations: MongoBulkWriteOperationLike[] = preparedItems.map((item, index) => ({
         updateOne: {
           filter: {
@@ -646,11 +642,7 @@ export function mongoDbEngine(options: MongoDbEngineOptions): MongoDbQueryEngine
       const persisted = Array.from({ length: preparedItems.length }, () => false);
 
       if (unconditionalItems.length > 0) {
-        const createdAts = await reserveCreatedAtRange(
-          metadataCollection,
-          collection,
-          unconditionalItems.length,
-        );
+        const createdAts = reserveCreatedAtRange(unconditionalItems.length);
         const operations: MongoBulkWriteOperationLike[] = unconditionalItems.map((item, index) => ({
           updateOne: {
             filter: {
@@ -1009,38 +1001,6 @@ async function ensureSchema(
       key: 1,
     });
   }
-}
-
-async function nextCreatedAt(
-  metadataCollection: MongoCollectionLike,
-  collection: string,
-): Promise<number> {
-  void metadataCollection;
-  void collection;
-
-  const createdAts = reserveDistributedCreatedAtRange(1);
-  const createdAt = createdAts[0];
-
-  if (createdAt === undefined) {
-    throw new Error("MongoDB failed to allocate createdAt");
-  }
-
-  return createdAt;
-}
-
-async function reserveCreatedAtRange(
-  metadataCollection: MongoCollectionLike,
-  collection: string,
-  count: number,
-): Promise<number[]> {
-  void metadataCollection;
-  void collection;
-
-  if (!Number.isInteger(count) || count <= 0) {
-    return [];
-  }
-
-  return reserveDistributedCreatedAtRange(count);
 }
 
 async function listCollectionDocuments(

--- a/tests/integration/firestore-engine.test.ts
+++ b/tests/integration/firestore-engine.test.ts
@@ -210,7 +210,7 @@ describe("firestoreEngine integration", () => {
       .get();
 
     expect(rawDoc.exists).toBe(true);
-    expect(rawSeq.exists).toBe(true);
+    expect(rawSeq.exists).toBe(false);
   });
 
   test("get returns deep clones", async () => {

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -1385,17 +1385,18 @@ describe("indexedDbEngine corruption handling", () => {
     await expectReject(engine.get("users", "bad"), /invalid record \(bad document\)/);
   });
 
-  test("create throws for invalid sequence metadata", async () => {
+  test("create ignores legacy sequence metadata", async () => {
     await engine.get("users", "bootstrap");
     await putRawRecord(RAW_STORE_META, {
       key: "sequence",
       value: "not-a-number",
     });
 
-    await expectReject(
-      engine.create("users", "u1", { id: "u1" }, { primary: "u1" }),
-      /invalid sequence record/,
-    );
+    await engine.create("users", "u1", { id: "u1" }, { primary: "u1" });
+
+    const created = await engine.get("users", "u1");
+
+    expect(created).toEqual({ id: "u1" });
   });
 
   test("acquireLock throws for invalid lock records", async () => {

--- a/tests/integration/mongodb-engine.test.ts
+++ b/tests/integration/mongodb-engine.test.ts
@@ -19,7 +19,6 @@ import {
   type ComparableVersion,
 } from "../../src";
 import { mongoDbEngine, type MongoDbQueryEngine } from "../../src/engines/mongodb";
-import { encodeQueryPageCursor } from "../../src/engines/query-cursor";
 import { runQueryEngineConformanceSuite } from "./conformance-suite";
 import {
   createCollectionNameFactory,
@@ -188,7 +187,7 @@ describe("mongoDbEngine integration", () => {
     });
 
     expect(rawDoc).not.toBeNull();
-    expect(rawSeq).not.toBeNull();
+    expect(rawSeq).toBeNull();
   });
 
   test("get returns deep clones", async () => {
@@ -477,22 +476,8 @@ describe("mongoDbEngine integration", () => {
     });
 
     expect(first.documents.map((item) => item.key)).toEqual(["u1", "u3"]);
-    expect(first.cursor).toBe(
-      encodeQueryPageCursor(
-        collection,
-        {
-          index: "byRole",
-          filter: { value: { $begins: "member#" } },
-          sort: "asc",
-          limit: 2,
-        },
-        {
-          key: "u3",
-          createdAt: 3,
-          indexValue: "member#b",
-        },
-      ),
-    );
+    expect(first.cursor).not.toBeNull();
+    expect(first.cursor).not.toBe("u3");
     expect(second.documents.map((item) => item.key)).toEqual(["u2"]);
     expect(second.cursor).toBeNull();
   });
@@ -566,22 +551,8 @@ describe("mongoDbEngine integration", () => {
     expect(noLimit.documents).toHaveLength(3);
     expect(noLimit.cursor).toBeNull();
     expect(fractional.documents).toHaveLength(1);
-    expect(fractional.cursor).toBe(
-      encodeQueryPageCursor(
-        collection,
-        {
-          index: "byRole",
-          filter: { value: { $begins: "member#" } },
-          sort: "asc",
-          limit: 1.9,
-        },
-        {
-          key: "u1",
-          createdAt: 1,
-          indexValue: "member#a",
-        },
-      ),
-    );
+    expect(fractional.cursor).not.toBeNull();
+    expect(fractional.cursor).not.toBe("u1");
   });
 
   test("query rejects raw key cursors and mismatched query cursors", async () => {

--- a/tests/unit/distributed-created-at.test.ts
+++ b/tests/unit/distributed-created-at.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { reserveCreatedAtRange } from "../../src/engines/distributed-created-at";
+
+describe("distributed createdAt allocation", () => {
+  test("allocates many ordered values without shared metadata state", () => {
+    const createdAts = reserveCreatedAtRange(5_000);
+    const uniqueCreatedAts = new Set(createdAts);
+
+    expect(uniqueCreatedAts.size).toBe(createdAts.length);
+
+    for (let index = 1; index < createdAts.length; index += 1) {
+      expect(createdAts[index]).toBeGreaterThan(createdAts[index - 1]!);
+    }
+  });
+});

--- a/tests/unit/dynamodb-engine.test.ts
+++ b/tests/unit/dynamodb-engine.test.ts
@@ -3,25 +3,18 @@ import {
   GetCommand,
   QueryCommand,
   TransactWriteCommand,
-  UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { describe, expect, test } from "bun:test";
 
 import { dynamoDbEngine } from "../../src/engines/dynamodb";
 
 class FakeDynamoClient {
-  sequenceValue = 0;
   sentCommands: string[] = [];
 
   constructor(private readonly existingDocument: Record<string, unknown> | null = null) {}
 
   async send(command: { input: unknown }): Promise<unknown> {
     this.sentCommands.push(command.constructor.name);
-
-    if (command instanceof UpdateCommand) {
-      this.sequenceValue += 1;
-      return { Attributes: { value: this.sequenceValue } };
-    }
 
     if (command instanceof GetCommand) {
       return { Item: this.existingDocument };
@@ -95,7 +88,7 @@ describe("dynamoDbEngine", () => {
     expect(engine.create("users", "u1", { id: "u1" }, makeIndexes(99))).rejects.toThrow(
       /100-item transaction limit/i,
     );
-    expect(client.sentCommands).toEqual(["UpdateCommand"]);
+    expect(client.sentCommands).toEqual([]);
   });
 
   test("delete fails fast when a single DynamoDB transaction would exceed 100 items", async () => {
@@ -120,6 +113,18 @@ describe("dynamoDbEngine", () => {
     expect(
       engine.batchSet("users", [{ key: "u1", doc: { id: "u1" }, indexes: makeIndexes(99) }]),
     ).rejects.toThrow(/100-item transaction limit/i);
-    expect(client.sentCommands).toEqual(["BatchGetCommand", "UpdateCommand"]);
+    expect(client.sentCommands).toEqual(["BatchGetCommand"]);
+  });
+
+  test("create does not reserve createdAt through a metadata update", async () => {
+    const client = new FakeDynamoClient();
+    const engine = dynamoDbEngine({
+      client,
+      tableName: "test-table",
+    });
+
+    await engine.create("users", "u1", { id: "u1" }, {});
+
+    expect(client.sentCommands).toEqual(["TransactWriteCommand"]);
   });
 });

--- a/tests/unit/firestore-engine.test.ts
+++ b/tests/unit/firestore-engine.test.ts
@@ -497,7 +497,7 @@ describe("firestoreEngine query execution", () => {
         { fieldPath: "createdAt", direction: "asc" },
         { fieldPath: "key", direction: "asc" },
       ],
-      startAfter: ["2025-02-01", 2, "u2"],
+      startAfter: ["2025-02-01", expect.any(Number), "u2"],
       limit: 3,
     });
   });
@@ -566,7 +566,7 @@ describe("firestoreEngine query execution", () => {
         { fieldPath: "createdAt", direction: "asc" },
         { fieldPath: "key", direction: "asc" },
       ],
-      startAfter: [3, "u3"],
+      startAfter: [expect.any(Number), "u3"],
       limit: 3,
     });
   });

--- a/tests/unit/mongodb-engine-batch.test.ts
+++ b/tests/unit/mongodb-engine-batch.test.ts
@@ -384,7 +384,7 @@ describe("mongodb engine batch operations", () => {
     expect(engine.capabilities?.uniqueConstraints).toBe("none");
   });
 
-  test("batchSet uses a single bulkWrite and sequence reservation for large batches", async () => {
+  test("batchSet uses a single bulkWrite without reserving a metadata sequence", async () => {
     const documents = new FakeMongoDocumentsCollection();
     const metadata = new FakeMongoMetadataCollection();
     const engine = mongoDbEngine({
@@ -405,7 +405,7 @@ describe("mongodb engine batch operations", () => {
     expect(documents.bulkWriteCalls).toHaveLength(1);
     expect(documents.bulkWriteCalls[0]?.operations).toHaveLength(items.length);
     expect(documents.updateOneCalls).toHaveLength(0);
-    expect(metadata.findOneAndUpdateCalls).toHaveLength(1);
+    expect(metadata.findOneAndUpdateCalls).toHaveLength(0);
   });
 
   test("batchSetWithResult bulk-writes unconditional items and keeps conditional conflict semantics", async () => {
@@ -427,7 +427,7 @@ describe("mongodb engine batch operations", () => {
     expect(documents.bulkWriteCalls).toHaveLength(1);
     expect(documents.bulkWriteCalls[0]?.operations).toHaveLength(2);
     expect(documents.updateOneCalls).toHaveLength(2);
-    expect(metadata.findOneAndUpdateCalls).toHaveLength(1);
+    expect(metadata.findOneAndUpdateCalls).toHaveLength(0);
   });
 
   test("batchSetWithResult throws when unconditional bulkWrite acknowledges fewer writes than expected", async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
 
     /* If your code doesn't run in the DOM: */
     "lib": ["es2022"]
-  }
+  },
+  "exclude": ["dist", "examples", "node_modules"]
 }


### PR DESCRIPTION
## Summary

Fixes #164 by removing the per-collection metadata sequence reservation from high-write create/upsert paths in the DynamoDB, MongoDB, Firestore, and IndexedDB adapters.

The adapters now allocate numeric, time-sortable `createdAt` values locally and continue to rely on the existing `(createdAt, key)` ordering for deterministic cursor pagination and tie-breaking. This avoids the single hot metadata record/document write that previously happened for every new document where these backends can safely avoid it.

## Impact

- DynamoDB create/upsert paths no longer issue a metadata `UpdateCommand` for sequence reservation.
- MongoDB batch upserts no longer call `findOneAndUpdate` on the metadata collection just to reserve createdAt ranges.
- Firestore create/upsert transactions no longer read and rewrite the sequence metadata document.
- IndexedDB create/upsert transactions no longer include the meta store solely to load/save a sequence record.
- Legacy IndexedDB sequence metadata is ignored by new writes rather than blocking creates.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

A patch changeset is included.