### PR TITLE
fix: prevent update downgrading future documents

### DIFF
--- a/.changeset/prevent-future-version-update-downgrade.md
+++ b/.changeset/prevent-future-version-update-downgrade.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Prevent `update()` from overwriting documents stored with a version newer than the current model schema.

--- a/src/store.ts
+++ b/src/store.ts
@@ -690,6 +690,11 @@ class BoundModelImpl<
       current = projected.value as Record<string, unknown>;
     } else {
       await this.handleProjectionFailure(projected.reason, key, "update", projected.error);
+
+      if (this.isUnsafeUpdateProjectionFallback(projected.reason)) {
+        throw this.createProjectionError(projected.reason, key, projected.error);
+      }
+
       // Ignore migration failures on read/merge path and attempt to apply the
       // update against the stored document as-is.
       current = existingDoc;
@@ -1271,6 +1276,10 @@ class BoundModelImpl<
 
   private shouldThrowProjectionErrors(): boolean {
     return this.model.options.migrationErrors === "throw";
+  }
+
+  private isUnsafeUpdateProjectionFallback(reason: ProjectionSkipReason): boolean {
+    return reason === "ahead_of_latest";
   }
 
   private async handleProjectionFailure(

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -5305,9 +5305,32 @@ describe("lazy migration error handling", () => {
       { primary: "u1", byEmail: "sam@example.com" },
     );
 
-    const store = createStore(engine, [buildUserV1()]);
+    const events: ProjectionSkippedEvent[] = [];
+    const store = createStore(engine, [buildUserV1()], {
+      projectionHooks: {
+        onProjectionSkipped(event) {
+          events.push(event);
+        },
+      },
+    });
 
     await expectReject(store.user.update("u1", { name: "Samuel" }), MigrationProjectionError);
+
+    expect(
+      events.map((event) => ({
+        model: event.model,
+        key: event.key,
+        reason: event.reason,
+        operation: event.operation,
+      })),
+    ).toEqual([
+      {
+        model: "user",
+        key: "u1",
+        reason: "ahead_of_latest",
+        operation: "update",
+      },
+    ]);
 
     const raw = (await engine.get("user", "u1")) as Record<string, unknown>;
     expect(raw).toEqual({

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -5290,6 +5290,34 @@ describe("lazy migration error handling", () => {
       },
     ]);
   });
+
+  test("update rejects ahead-of-latest documents without downgrading when migration errors are ignored", async () => {
+    await engine.put(
+      "user",
+      "u1",
+      {
+        __v: 2,
+        id: "u1",
+        name: "Sam",
+        email: "sam@example.com",
+        futureOnly: "preserve me",
+      },
+      { primary: "u1", byEmail: "sam@example.com" },
+    );
+
+    const store = createStore(engine, [buildUserV1()]);
+
+    await expectReject(store.user.update("u1", { name: "Samuel" }), MigrationProjectionError);
+
+    const raw = (await engine.get("user", "u1")) as Record<string, unknown>;
+    expect(raw).toEqual({
+      __v: 2,
+      id: "u1",
+      name: "Sam",
+      email: "sam@example.com",
+      futureOnly: "preserve me",
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Reject `store.model.update()` when the stored document is ahead of the model's latest schema version, even when `migrationErrors: "ignore"` is configured.
- Preserve the existing projection skip hook behavior before rejecting the unsafe update fallback.
- Add a regression test proving the rejected update does not write back a downgraded document.
- Add a patch changeset.

Closes #177.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun test ./tests/unit/store.test.ts`
- `bun run test`
- `bun typecheck`