### PR TITLE
[codex] Reject unsafe store model names

### DIFF
--- a/.changeset/reject-unsafe-store-model-names.md
+++ b/.changeset/reject-unsafe-store-model-names.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Reject store model names that collide with unsafe object properties such as `__proto__`, `prototype`, and `constructor`.

--- a/src/store.ts
+++ b/src/store.ts
@@ -198,6 +198,8 @@ const RESERVED_STORE_API_NAMES = new Set([
   "migrateAll",
 ]);
 
+const UNSAFE_STORE_MODEL_NAMES = new Set(["__proto__", "prototype", "constructor"]);
+
 // ---------------------------------------------------------------------------
 // Errors
 // ---------------------------------------------------------------------------
@@ -2000,6 +2002,10 @@ export function createStore<
   for (const modelDef of models) {
     if (RESERVED_STORE_API_NAMES.has(modelDef.name)) {
       throw new Error(`Model name "${modelDef.name}" collides with a store-level API`);
+    }
+
+    if (UNSAFE_STORE_MODEL_NAMES.has(modelDef.name)) {
+      throw new Error(`Model name "${modelDef.name}" collides with an unsafe object property`);
     }
 
     if (boundModels.has(modelDef.name)) {

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -682,6 +682,28 @@ describe("createStore()", () => {
     }
   });
 
+  test("throws when model names collide with unsafe object properties", () => {
+    const unsafeNames = ["__proto__", "prototype", "constructor"] as const;
+
+    for (const unsafeName of unsafeNames) {
+      const unsafeModel = model(unsafeName)
+        .schema(
+          1,
+          z.object({
+            id: z.string(),
+          }),
+        )
+        .index({ name: "primary", value: "id" })
+        .build();
+
+      expect(() => {
+        createStore(engine, [unsafeModel]);
+      }).toThrow(`Model name "${unsafeName}" collides with an unsafe object property`);
+
+      expect(Object.getPrototypeOf({})).toBe(Object.prototype);
+    }
+  });
+
   test("creates a store with a single model", () => {
     const store = createStore(engine, [buildUserV1()]);
 


### PR DESCRIPTION
## Summary

Reject model names that collide with prototype-related object properties before `createStore()` binds models onto the returned store object.

## Why

Fixes #178. `createStore()` already rejected store-level API names, but it still allowed names such as `__proto__`, `prototype`, and `constructor`. Because bound models are assigned as object properties, those names can create surprising prototype/property behavior instead of a normal model binding.

## Changes

- Added an explicit unsafe model-name guard for `__proto__`, `prototype`, and `constructor`.
- Added regression coverage proving those names are rejected and do not mutate normal object prototype behavior.
- Added a patch changeset for the release note.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`

Note: I also accidentally started bare `bun test`, which discovers integration tests too; I stopped it and reran the project-defined unit test script above.