### PR TITLE
[codex] Fix Unicode-safe $begins pushdown ranges

### DIFF
--- a/.changeset/fix-unicode-begins-fallback.md
+++ b/.changeset/fix-unicode-begins-fallback.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": patch
+---
+
+Fix Unicode correctness for `$begins` queries in Firestore, IndexedDB, and Redis by avoiding sentinel-based prefix range pushdown when the backend cannot express a safe prefix predicate.

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -1031,19 +1031,12 @@ function buildFirestoreWhereFilters(
     return null;
   }
 
-  if (hasBetween && (hasEq || hasBegins || hasRange)) {
+  if (hasBetween && (hasEq || hasRange)) {
     return null;
   }
 
   if (hasEq) {
     return [{ op: "==", value: String(filter.$eq as string | number) }];
-  }
-
-  if (hasBegins) {
-    return [
-      { op: ">=", value: filter.$begins },
-      { op: "<=", value: `${filter.$begins}\uf8ff` },
-    ];
   }
 
   if (hasBetween) {

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -1027,7 +1027,7 @@ function buildFirestoreWhereFilters(
     return null;
   }
 
-  if (hasBegins && (hasEq || hasBetween || hasRange)) {
+  if (hasBegins) {
     return null;
   }
 

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -1108,12 +1108,7 @@ function resolveIndexRangeBounds(condition: FieldCondition): {
   upperOpen: boolean;
 } | null {
   if (condition.$begins !== undefined) {
-    return {
-      lower: condition.$begins,
-      upper: `${condition.$begins}\uffff`,
-      lowerOpen: false,
-      upperOpen: false,
-    };
+    return null;
   }
 
   if (condition.$between !== undefined) {

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -2204,10 +2204,7 @@ function buildIndexLexRange(filter: string | number | FieldCondition): IndexLexR
     filter.$lte === undefined &&
     filter.$between === undefined
   ) {
-    return {
-      min: `[${filter.$begins}`,
-      max: `[${filter.$begins}\xff`,
-    };
+    return null;
   }
 
   if (filter.$between !== undefined) {

--- a/tests/integration/conformance-suite.ts
+++ b/tests/integration/conformance-suite.ts
@@ -156,6 +156,37 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
       expect(page2.cursor).toBeNull();
     });
 
+    test("applies $begins semantics to Unicode suffixes above sentinel ranges", async () => {
+      const engine = getEngine();
+      const collection = nextCollection("unicode_prefix_users");
+
+      await engine.batchSet(collection, [
+        {
+          key: "u1",
+          doc: { id: "u1", role: "private-use" },
+          indexes: { byRole: "member#\uf900" },
+        },
+        {
+          key: "u2",
+          doc: { id: "u2", role: "emoji" },
+          indexes: { byRole: "member#😀" },
+        },
+        {
+          key: "u3",
+          doc: { id: "u3", role: "other" },
+          indexes: { byRole: "admin#\uf900" },
+        },
+      ]);
+
+      const results = await engine.query(collection, {
+        index: "byRole",
+        filter: { value: { $begins: "member#" } },
+        sort: "asc",
+      });
+
+      expect(results.documents.map((entry) => entry.key).sort()).toEqual(["u1", "u2"]);
+    });
+
     test("uses opaque, query-bound cursors that resume correctly after cursor row deletion", async () => {
       const engine = getEngine();
       const collection = nextCollection("cursor_users");

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -949,6 +949,35 @@ describe("indexedDbEngine query behavior", () => {
     }
   });
 
+  test("$begins fallback includes Unicode suffixes above old IndexedDB sentinels", async () => {
+    const keyRangeGlobal = globalThis as typeof globalThis & {
+      IDBKeyRange?: typeof IDBKeyRange;
+    };
+    const previousKeyRange = keyRangeGlobal.IDBKeyRange;
+    keyRangeGlobal.IDBKeyRange = IDBKeyRange;
+
+    try {
+      await engine.put("items", "a", { id: "a" }, { byRole: "member#\uf900" });
+      await engine.put("items", "b", { id: "b" }, { byRole: "member#😀" });
+      await engine.put("items", "c", { id: "c" }, { byRole: "admin#\uf900" });
+
+      const results = await engine.query("items", {
+        index: "byRole",
+        filter: { value: { $begins: "member#" } },
+        sort: "asc",
+      });
+
+      expect(results.documents.map((item) => item.key).sort()).toEqual(["a", "b"]);
+      expect(results.diagnostics).toEqual({
+        mode: "fallback_scan",
+        reason: "fallback_scan",
+        index: "byRole",
+      });
+    } finally {
+      keyRangeGlobal.IDBKeyRange = previousKeyRange;
+    }
+  });
+
   test("query sort asc/desc for indexed queries", async () => {
     await engine.put("items", "a", { id: "a" }, { byDate: "2025-03-01" });
     await engine.put("items", "b", { id: "b" }, { byDate: "2025-01-01" });

--- a/tests/integration/redis-engine.test.ts
+++ b/tests/integration/redis-engine.test.ts
@@ -456,7 +456,7 @@ describe("redisEngine integration", () => {
 
     const results = await engine.query(collection, {
       index: "byRole",
-      filter: { value: { $begins: "member#" } },
+      filter: { value: { $between: ["member#a", "member#b"] } },
       sort: "asc",
     });
 

--- a/tests/unit/firestore-engine.test.ts
+++ b/tests/unit/firestore-engine.test.ts
@@ -432,7 +432,7 @@ describe("firestoreEngine query execution", () => {
     expect(results.map((entry) => entry.key)).toEqual(requestKeys);
   });
 
-  test("query pushes sorted pagination into Firestore when the query is expressible", async () => {
+  test("query falls back for $begins because Firestore has no Unicode-safe prefix range", async () => {
     const database = new FakeFirestoreDatabase();
     const engine = createEngine(database);
 
@@ -463,18 +463,10 @@ describe("firestoreEngine query execution", () => {
 
     expect(firstPage.documents.map((entry) => entry.key)).toEqual(["u3", "u2"]);
     expect(database.instrumentation.queryReads.at(-1)).toEqual({
-      filters: [
-        { fieldPath: "collection", opStr: "==", value: "users" },
-        { fieldPath: "indexes.byCreatedAt", opStr: ">=", value: "2025-" },
-        { fieldPath: "indexes.byCreatedAt", opStr: "<=", value: "2025-\uf8ff" },
-      ],
-      orderBy: [
-        { fieldPath: "indexes.byCreatedAt", direction: "desc" },
-        { fieldPath: "createdAt", direction: "asc" },
-        { fieldPath: "key", direction: "asc" },
-      ],
+      filters: [{ fieldPath: "collection", opStr: "==", value: "users" }],
+      orderBy: [],
       startAfter: [],
-      limit: 3,
+      limit: null,
     });
 
     const secondPage = await engine.query("users", {
@@ -487,18 +479,47 @@ describe("firestoreEngine query execution", () => {
 
     expect(secondPage.documents.map((entry) => entry.key)).toEqual(["u1"]);
     expect(database.instrumentation.queryReads.at(-1)).toEqual({
-      filters: [
-        { fieldPath: "collection", opStr: "==", value: "users" },
-        { fieldPath: "indexes.byCreatedAt", opStr: ">=", value: "2025-" },
-        { fieldPath: "indexes.byCreatedAt", opStr: "<=", value: "2025-\uf8ff" },
-      ],
-      orderBy: [
-        { fieldPath: "indexes.byCreatedAt", direction: "desc" },
-        { fieldPath: "createdAt", direction: "asc" },
-        { fieldPath: "key", direction: "asc" },
-      ],
-      startAfter: ["2025-02-01", expect.any(Number), "u2"],
-      limit: 3,
+      filters: [{ fieldPath: "collection", opStr: "==", value: "users" }],
+      orderBy: [],
+      startAfter: [],
+      limit: null,
+    });
+  });
+
+  test("$begins fallback includes Unicode suffixes above old Firestore sentinels", async () => {
+    const database = new FakeFirestoreDatabase();
+    const engine = createEngine(database);
+
+    await engine.batchSet("users", [
+      {
+        key: "u1",
+        doc: { id: "u1" },
+        indexes: { byRole: "member#\uf900" },
+      },
+      {
+        key: "u2",
+        doc: { id: "u2" },
+        indexes: { byRole: "member#😀" },
+      },
+      {
+        key: "u3",
+        doc: { id: "u3" },
+        indexes: { byRole: "admin#\uf900" },
+      },
+    ]);
+
+    const results = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
+
+    expect(results.documents.map((entry) => entry.key).sort()).toEqual(["u1", "u2"]);
+    expect(database.instrumentation.queryReads.at(-1)).toEqual({
+      filters: [{ fieldPath: "collection", opStr: "==", value: "users" }],
+      orderBy: [],
+      startAfter: [],
+      limit: null,
     });
   });
 

--- a/tests/unit/non-sql-query-pushdown.test.ts
+++ b/tests/unit/non-sql-query-pushdown.test.ts
@@ -989,11 +989,12 @@ describe("non-SQL query pushdown", () => {
     expect(String(logged[0]?.[0])).toContain("onQueryFallbackScan");
   });
 
-  test("firestore query pushes supported index filters into where clauses", async () => {
+  test("firestore query falls back for $begins to avoid Unicode-unsafe sentinels", async () => {
     const db = new FakeFirestoreDatabase([
       makeEngineDoc("u1", 2, { byEmail: "sam@example.com" }, { id: "u1" }),
       makeEngineDoc("u2", 1, { byEmail: "alex@example.com" }, { id: "u2" }),
       makeEngineDoc("u3", 3, { byEmail: "zoe@example.com" }, { id: "u3" }),
+      makeEngineDoc("u4", 4, { byEmail: "a\uf900@example.com" }, { id: "u4" }),
     ]);
     const engine = firestoreEngine({
       database: db as unknown as Parameters<typeof firestoreEngine>[0]["database"],
@@ -1004,12 +1005,8 @@ describe("non-SQL query pushdown", () => {
       filter: { value: { $begins: "a" } },
     });
 
-    expect(db.documentWhereCalls).toEqual([
-      { field: "collection", op: "==", value: "users" },
-      { field: "indexes.byEmail", op: ">=", value: "a" },
-      { field: "indexes.byEmail", op: "<=", value: "a\uf8ff" },
-    ]);
-    expect(result.documents.map((doc) => doc.key)).toEqual(["u2"]);
+    expect(db.documentWhereCalls).toEqual([{ field: "collection", op: "==", value: "users" }]);
+    expect(result.documents.map((doc) => doc.key)).toEqual(["u2", "u4"]);
   });
 
   test("firestore query rejects malformed cursor before backend query", async () => {

--- a/tests/unit/redis-engine.test.ts
+++ b/tests/unit/redis-engine.test.ts
@@ -310,7 +310,7 @@ describe("redisEngine", () => {
     expect(client.hashReads).toBe(0);
   });
 
-  test("sorted indexed query does not fall back to collection order scans", async () => {
+  test("sorted indexed query falls back for $begins because Redis has no Unicode-safe prefix range", async () => {
     await engine.put("users", "u1", { id: "u1" }, { byRole: "member#a" });
     await engine.put("users", "u2", { id: "u2" }, { byRole: "member#b" });
 
@@ -328,8 +328,23 @@ describe("redisEngine", () => {
     });
 
     expect(results.documents.map((item) => item.key)).toEqual(["u1", "u2"]);
-    expect(client.indexPageCalls).toBeGreaterThan(0);
-    expect(client.zRangeCalls).not.toContain(collectionOrderKey("test", "users"));
+    expect(client.indexPageCalls).toBe(0);
+    expect(client.zRangeCalls).toContain(collectionOrderKey("test", "users"));
+  });
+
+  test("$begins fallback includes Unicode suffixes above old Redis sentinel", async () => {
+    await engine.put("users", "u1", { id: "u1" }, { byRole: "member#\uf900" });
+    await engine.put("users", "u2", { id: "u2" }, { byRole: "member#😀" });
+    await engine.put("users", "u3", { id: "u3" }, { byRole: "admin#\uf900" });
+
+    const results = await engine.query("users", {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+    });
+
+    expect(results.documents.map((item) => item.key).sort()).toEqual(["u1", "u2"]);
+    expect(client.indexPageCalls).toBe(0);
   });
 
   test("sorted indexed query backfills legacy documents before using the index set", async () => {


### PR DESCRIPTION
## Summary

Fixes #180.

This changes Firestore, IndexedDB, and Redis query planning so `$begins` no longer uses sentinel upper bounds such as `prefix + "\uf8ff"`, `prefix + "\uffff"`, or `prefix + "\xff"`. Those sentinels are not a database-agnostic Unicode-safe representation of every string beginning with the prefix, so these adapters now use their existing fallback filtering path for `$begins` when the backend cannot express a correct prefix predicate.

## Root Cause

The affected adapters converted `$begins` into native range predicates using backend-specific sentinel suffixes. Values containing characters above those sentinels could be excluded before the shared `startsWith` filter had a chance to run, which made native pushed-down query results diverge from fallback semantics.

## Changes

- Firestore no longer builds native where range clauses for `$begins`.
- IndexedDB no longer builds `IDBKeyRange` bounds for `$begins`.
- Redis no longer builds lex ranges for sorted-index `$begins` queries.
- Added regression coverage for high Unicode and emoji suffixes, plus shared conformance coverage for prefix matching semantics.
- Added a patch changeset for the fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun run test`
- `bun typecheck`
- `bun lint`
- `bun run test:integration:memory`
- `bun run test:integration:indexeddb`
- `git diff --check`