### PR TITLE
fix: emit adapter query diagnostics

### DIFF
--- a/.changeset/emit-adapter-query-diagnostics.md
+++ b/.changeset/emit-adapter-query-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": minor
+---
+
+Emit query diagnostics from all bundled adapter query paths so consumers can monitor native pushdown, fallback scans, and full collection scans consistently.

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ Pass `queryDiagnostics.onQueryDiagnostic` to `createStore()` when you want to mo
 const store = createStore(engine, [User], {
   queryDiagnostics: {
     onQueryDiagnostic(event) {
-      if (event.reason === "full_scan" || event.mode === "fallback_scan") {
+      if (event.mode === "fallback_scan") {
         console.warn("Query fallback", event.model, event.reason, event.index);
       }
     },

--- a/README.md
+++ b/README.md
@@ -630,6 +630,24 @@ const page2 = await store.user.query({
 - `documents`: typed model documents
 - `cursor`: `string | null` opaque continuation token for keyset pagination
 
+Query diagnostics:
+
+Pass `queryDiagnostics.onQueryDiagnostic` to `createStore()` when you want to monitor query execution across adapters. The hook fires after each `query()` call with the resolved model, query shape, execution `mode`, diagnostic `reason`, and index name when available.
+
+```ts
+const store = createStore(engine, [User], {
+  queryDiagnostics: {
+    onQueryDiagnostic(event) {
+      if (event.reason === "full_scan" || event.mode === "fallback_scan") {
+        console.warn("Query fallback", event.model, event.reason, event.index);
+      }
+    },
+  },
+});
+```
+
+Bundled adapters emit diagnostics for indexed queries and full collection scans. Common values are `native_pushdown` for adapter-native indexed lookups, `fallback_scan`/`full_scan` for collection scans, and `fallback_scan`/`unsupported_filter` when an adapter has to filter outside its native query path.
+
 Cursor contract:
 
 - Treat cursors as opaque values (do not parse or construct them manually).

--- a/src/engines/cassandra.ts
+++ b/src/engines/cassandra.ts
@@ -1,6 +1,7 @@
 import { DefaultMigrator } from "../migrator";
 import { getPreparedSerializedDocument, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
+import { queryDiagnosticsForCollectionScan, withQueryDiagnostics } from "./query-diagnostics";
 import {
   type BatchSetItem,
   type BatchSetResult,
@@ -246,7 +247,10 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       const rows = await listCollectionDocuments(client, documentsTable, collection);
       const matched = matchDocuments(rows, params);
 
-      return paginate(collection, matched, params);
+      return withQueryDiagnostics(
+        paginate(collection, matched, params),
+        queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async queryWithMetadata(collection, params) {
@@ -255,7 +259,10 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       const rows = await listCollectionDocuments(client, documentsTable, collection);
       const matched = matchDocuments(rows, params);
 
-      return paginateWithWriteTokens(collection, matched, params);
+      return withQueryDiagnostics(
+        paginateWithWriteTokens(collection, matched, params),
+        queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async batchGet(collection, keys) {

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -391,7 +391,9 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
 
       return withQueryDiagnostics(
         paginate(collection, matched, params),
-        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+        queried !== null
+          ? queryDiagnosticsForIndexedQuery(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 
@@ -402,7 +404,9 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
 
       return withQueryDiagnostics(
         paginateWithWriteTokens(collection, matched, params),
-        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+        queried !== null
+          ? queryDiagnosticsForIndexedQuery(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 

--- a/src/engines/dynamodb.ts
+++ b/src/engines/dynamodb.ts
@@ -17,6 +17,11 @@ import { nextCreatedAt } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
   type ComparableVersion,
@@ -380,21 +385,25 @@ export function dynamoDbEngine(options: DynamoDbEngineOptions): DynamoDbQueryEng
     },
 
     async query(collection, params) {
-      const records =
-        (await listDocumentsByQuery(client, tableName, keyConfig, collection, params)) ??
-        (await listDocuments(client, tableName, keyConfig, collection));
+      const queried = await listDocumentsByQuery(client, tableName, keyConfig, collection, params);
+      const records = queried ?? (await listDocuments(client, tableName, keyConfig, collection));
       const matched = matchDocuments(records, params);
 
-      return paginate(collection, matched, params);
+      return withQueryDiagnostics(
+        paginate(collection, matched, params),
+        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async queryWithMetadata(collection, params) {
-      const records =
-        (await listDocumentsByQuery(client, tableName, keyConfig, collection, params)) ??
-        (await listDocuments(client, tableName, keyConfig, collection));
+      const queried = await listDocumentsByQuery(client, tableName, keyConfig, collection, params);
+      const records = queried ?? (await listDocuments(client, tableName, keyConfig, collection));
       const matched = matchDocuments(records, params);
 
-      return paginateWithWriteTokens(collection, matched, params);
+      return withQueryDiagnostics(
+        paginateWithWriteTokens(collection, matched, params),
+        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async batchGet(collection, keys) {

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -10,6 +10,11 @@ import {
   validateQueryPageCursor,
 } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
@@ -319,15 +324,22 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
         null;
 
       if (paged) {
-        return paged;
+        return withQueryDiagnostics(
+          paged,
+          params.index && params.filter
+            ? queryDiagnosticsForIndexedQuery(params)
+            : queryDiagnosticsForCollectionScan(),
+        );
       }
 
-      const records =
-        (await listCollectionDocumentsByQuery(documentsCollection, collection, params)) ??
-        (await listCollectionDocuments(documentsCollection, collection));
+      const queried = await listCollectionDocumentsByQuery(documentsCollection, collection, params);
+      const records = queried ?? (await listCollectionDocuments(documentsCollection, collection));
       const matched = matchDocuments(records, params);
 
-      return paginate(collection, matched, params);
+      return withQueryDiagnostics(
+        paginate(collection, matched, params),
+        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async queryWithMetadata(collection, params) {
@@ -336,15 +348,22 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
         (await queryCollectionDocumentsPage(documentsCollection, collection, params, true)) ?? null;
 
       if (paged) {
-        return paged;
+        return withQueryDiagnostics(
+          paged,
+          params.index && params.filter
+            ? queryDiagnosticsForIndexedQuery(params)
+            : queryDiagnosticsForCollectionScan(),
+        );
       }
 
-      const records =
-        (await listCollectionDocumentsByQuery(documentsCollection, collection, params)) ??
-        (await listCollectionDocuments(documentsCollection, collection));
+      const queried = await listCollectionDocumentsByQuery(documentsCollection, collection, params);
+      const records = queried ?? (await listCollectionDocuments(documentsCollection, collection));
       const matched = matchDocuments(records, params);
 
-      return paginateWithWriteTokens(collection, matched, params);
+      return withQueryDiagnostics(
+        paginateWithWriteTokens(collection, matched, params),
+        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async batchGet(collection, keys) {

--- a/src/engines/firestore.ts
+++ b/src/engines/firestore.ts
@@ -338,7 +338,9 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
 
       return withQueryDiagnostics(
         paginate(collection, matched, params),
-        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+        queried !== null
+          ? queryDiagnosticsForIndexedQuery(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 
@@ -362,7 +364,9 @@ export function firestoreEngine(options: FirestoreEngineOptions): FirestoreQuery
 
       return withQueryDiagnostics(
         paginateWithWriteTokens(collection, matched, params),
-        queried ? queryDiagnosticsForIndexedQuery(params) : queryDiagnosticsForCollectionScan(),
+        queried !== null
+          ? queryDiagnosticsForIndexedQuery(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -5,6 +5,7 @@ import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-curso
 import {
   queryDiagnosticsForCollectionScan,
   queryDiagnosticsForUnsupportedFilter,
+  withQueryDiagnostics,
 } from "./query-diagnostics";
 import {
   EngineDocumentAlreadyExistsError,
@@ -461,7 +462,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       const records = indexed?.records ?? (await listCollectionDocuments(db, collection));
       const matched = matchDocuments(records, params);
 
-      return withDiagnostics(
+      return withQueryDiagnostics(
         paginateQuery(collection, matched, params),
         indexed?.diagnostics ??
           (params.index && params.filter
@@ -476,7 +477,7 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
       const records = indexed?.records ?? (await listCollectionDocuments(db, collection));
       const matched = matchDocuments(records, params);
 
-      return withDiagnostics(
+      return withQueryDiagnostics(
         paginateQuery(collection, matched, params, true),
         indexed?.diagnostics ??
           (params.index && params.filter
@@ -1420,16 +1421,6 @@ function paginateQuery(
         : document;
     }),
     cursor,
-  };
-}
-
-function withDiagnostics(
-  result: EngineQueryResult,
-  diagnostics: EngineQueryDiagnostics,
-): EngineQueryResult {
-  return {
-    ...result,
-    diagnostics,
   };
 }
 

--- a/src/engines/indexeddb.ts
+++ b/src/engines/indexeddb.ts
@@ -3,6 +3,10 @@ import { nextCreatedAt, reserveCreatedAtRange } from "./distributed-created-at";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForUnsupportedFilter,
+} from "./query-diagnostics";
+import {
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
   EngineUniqueConstraintError,
@@ -459,11 +463,10 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       return withDiagnostics(
         paginateQuery(collection, matched, params),
-        indexed?.diagnostics ?? {
-          mode: "fallback_scan",
-          reason: "fallback_scan",
-          ...(params.index ? { index: params.index } : {}),
-        },
+        indexed?.diagnostics ??
+          (params.index && params.filter
+            ? queryDiagnosticsForUnsupportedFilter(params)
+            : queryDiagnosticsForCollectionScan()),
       );
     },
 
@@ -475,11 +478,10 @@ export function indexedDbEngine(options?: IndexedDbEngineOptions): IndexedDbQuer
 
       return withDiagnostics(
         paginateQuery(collection, matched, params, true),
-        indexed?.diagnostics ?? {
-          mode: "fallback_scan",
-          reason: "fallback_scan",
-          ...(params.index ? { index: params.index } : {}),
-        },
+        indexed?.diagnostics ??
+          (params.index && params.filter
+            ? queryDiagnosticsForUnsupportedFilter(params)
+            : queryDiagnosticsForCollectionScan()),
       );
     },
 

--- a/src/engines/memory.ts
+++ b/src/engines/memory.ts
@@ -2,6 +2,10 @@ import { DefaultMigrator } from "../migrator";
 import { getPreparedClone, prepareDocumentForStorage } from "./document-preparation";
 import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+} from "./query-diagnostics";
+import {
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
   EngineUniqueConstraintError,
@@ -233,15 +237,8 @@ export function memoryEngine(options?: MemoryEngineOptions): MemoryQueryEngine {
         ...paginateQuery(collection, results, params),
         diagnostics:
           params.index && params.filter
-            ? {
-                mode: "native_pushdown",
-                reason: "native_pushdown",
-                index: params.index,
-              }
-            : {
-                mode: "fallback_scan",
-                reason: "full_scan",
-              },
+            ? queryDiagnosticsForIndexedQuery(params)
+            : queryDiagnosticsForCollectionScan(),
       };
     },
 

--- a/src/engines/mysql.ts
+++ b/src/engines/mysql.ts
@@ -9,6 +9,11 @@ import {
   type QueryCursorPosition,
 } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   type BatchSetItem,
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
@@ -625,10 +630,13 @@ async function queryByCollectionScan(
   const limit = normalizeLimit(params.limit);
 
   if (limit === 0) {
-    return {
-      documents: [],
-      cursor: null,
-    };
+    return withQueryDiagnostics(
+      {
+        documents: [],
+        cursor: null,
+      },
+      queryDiagnosticsForCollectionScan(),
+    );
   }
 
   const cursorPosition = resolveQueryPageCursorPosition(collection, params);
@@ -658,7 +666,10 @@ async function queryByCollectionScan(
     errorMessage: "MySQL returned an invalid query result",
   });
 
-  return formatPage(rows, params, collection, includeWriteTokens);
+  return withQueryDiagnostics(
+    formatPage(rows, params, collection, includeWriteTokens),
+    queryDiagnosticsForCollectionScan(),
+  );
 }
 
 async function queryByIndex(
@@ -671,10 +682,13 @@ async function queryByIndex(
   const limit = normalizeLimit(params.limit);
 
   if (limit === 0) {
-    return {
-      documents: [],
-      cursor: null,
-    };
+    return withQueryDiagnostics(
+      {
+        documents: [],
+        cursor: null,
+      },
+      queryDiagnosticsForIndexedQuery(params),
+    );
   }
 
   const index = params.index!;
@@ -755,7 +769,10 @@ async function queryByIndex(
     errorMessage: "MySQL returned an invalid query result",
   });
 
-  return formatPage(rows, params, collection, includeWriteTokens);
+  return withQueryDiagnostics(
+    formatPage(rows, params, collection, includeWriteTokens),
+    queryDiagnosticsForIndexedQuery(params),
+  );
 }
 
 function formatPage(

--- a/src/engines/postgres.ts
+++ b/src/engines/postgres.ts
@@ -7,6 +7,11 @@ import {
   type QueryCursorPosition,
 } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   type BatchSetItem,
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
@@ -663,10 +668,13 @@ async function queryByCollectionScan(
   const limit = normalizeLimit(params.limit);
 
   if (limit === 0) {
-    return {
-      documents: [],
-      cursor: null,
-    };
+    return withQueryDiagnostics(
+      {
+        documents: [],
+        cursor: null,
+      },
+      queryDiagnosticsForCollectionScan(),
+    );
   }
 
   const cursorPosition = resolveQueryPageCursorPosition(collection, params);
@@ -696,7 +704,10 @@ async function queryByCollectionScan(
     errorMessage: "Postgres returned an invalid query result",
   });
 
-  return formatPage(rows, params, collection, includeWriteTokens);
+  return withQueryDiagnostics(
+    formatPage(rows, params, collection, includeWriteTokens),
+    queryDiagnosticsForCollectionScan(),
+  );
 }
 
 async function queryByIndex(
@@ -709,10 +720,13 @@ async function queryByIndex(
   const limit = normalizeLimit(params.limit);
 
   if (limit === 0) {
-    return {
-      documents: [],
-      cursor: null,
-    };
+    return withQueryDiagnostics(
+      {
+        documents: [],
+        cursor: null,
+      },
+      queryDiagnosticsForIndexedQuery(params),
+    );
   }
 
   const index = params.index!;
@@ -795,7 +809,10 @@ async function queryByIndex(
     errorMessage: "Postgres returned an invalid query result",
   });
 
-  return formatPage(rows, params, collection, includeWriteTokens);
+  return withQueryDiagnostics(
+    formatPage(rows, params, collection, includeWriteTokens),
+    queryDiagnosticsForIndexedQuery(params),
+  );
 }
 
 function formatPage(

--- a/src/engines/query-diagnostics.ts
+++ b/src/engines/query-diagnostics.ts
@@ -1,0 +1,34 @@
+import type { EngineQueryDiagnostics, EngineQueryResult, QueryParams } from "./types";
+
+export function queryDiagnosticsForIndexedQuery(params: QueryParams): EngineQueryDiagnostics {
+  return {
+    mode: "native_pushdown",
+    reason: "native_pushdown",
+    ...(params.index ? { index: params.index } : {}),
+  };
+}
+
+export function queryDiagnosticsForCollectionScan(): EngineQueryDiagnostics {
+  return {
+    mode: "fallback_scan",
+    reason: "full_scan",
+  };
+}
+
+export function queryDiagnosticsForUnsupportedFilter(params: QueryParams): EngineQueryDiagnostics {
+  return {
+    mode: "fallback_scan",
+    reason: "unsupported_filter",
+    ...(params.index ? { index: params.index } : {}),
+  };
+}
+
+export function withQueryDiagnostics(
+  result: EngineQueryResult,
+  diagnostics: EngineQueryDiagnostics,
+): EngineQueryResult {
+  return {
+    ...result,
+    diagnostics,
+  };
+}

--- a/src/engines/redis.ts
+++ b/src/engines/redis.ts
@@ -6,6 +6,12 @@ import {
   resolveQueryPageStartIndex,
 } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  queryDiagnosticsForUnsupportedFilter,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
   EngineDocumentNotFoundError,
@@ -745,24 +751,40 @@ export function redisEngine(options: RedisEngineOptions): RedisQueryEngine {
       const range = params.index && params.filter ? buildIndexLexRange(params.filter.value) : null;
 
       if (params.index && params.filter && params.sort && range) {
-        return querySortedIndex(client, keyPrefix, collection, params, range, false);
+        return withQueryDiagnostics(
+          await querySortedIndex(client, keyPrefix, collection, params, range, false),
+          queryDiagnosticsForIndexedQuery(params),
+        );
       }
 
       const matched = await findMatchingDocuments(client, keyPrefix, collection, params);
 
-      return paginate(collection, matched, params);
+      return withQueryDiagnostics(
+        paginate(collection, matched, params),
+        params.index && params.filter
+          ? queryDiagnosticsForUnsupportedFilter(params)
+          : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async queryWithMetadata(collection, params) {
       const range = params.index && params.filter ? buildIndexLexRange(params.filter.value) : null;
 
       if (params.index && params.filter && params.sort && range) {
-        return querySortedIndex(client, keyPrefix, collection, params, range, true);
+        return withQueryDiagnostics(
+          await querySortedIndex(client, keyPrefix, collection, params, range, true),
+          queryDiagnosticsForIndexedQuery(params),
+        );
       }
 
       const matched = await findMatchingDocuments(client, keyPrefix, collection, params);
 
-      return paginateWithWriteTokens(collection, matched, params);
+      return withQueryDiagnostics(
+        paginateWithWriteTokens(collection, matched, params),
+        params.index && params.filter
+          ? queryDiagnosticsForUnsupportedFilter(params)
+          : queryDiagnosticsForCollectionScan(),
+      );
     },
 
     async batchGet(collection, keys) {

--- a/src/engines/sqlite.ts
+++ b/src/engines/sqlite.ts
@@ -9,6 +9,11 @@ import {
   type QueryCursorPosition,
 } from "./query-cursor";
 import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
+import {
   type BatchSetItem,
   type BatchSetResult,
   EngineDocumentAlreadyExistsError,
@@ -868,7 +873,10 @@ export function sqliteEngine(options: SqliteEngineOptions): SqliteQueryEngine {
     const limit = normalizeLimit(params.limit);
 
     if (limit === 0) {
-      return { documents: [], cursor: null };
+      return withQueryDiagnostics(
+        { documents: [], cursor: null },
+        queryDiagnosticsForCollectionScan(),
+      );
     }
 
     const cursorPosition = resolveQueryPageCursorPosition(collection, params);
@@ -881,7 +889,10 @@ export function sqliteEngine(options: SqliteEngineOptions): SqliteQueryEngine {
     const fetchLimit = limit === null ? Number.MAX_SAFE_INTEGER : limit + 1;
     const rows = queryScanPageStmt.all(collection, cursorId, fetchLimit);
 
-    return formatPage(rows, params, collection, includeWriteTokens);
+    return withQueryDiagnostics(
+      formatPage(rows, params, collection, includeWriteTokens),
+      queryDiagnosticsForCollectionScan(),
+    );
   }
 
   function queryByIndex(
@@ -892,7 +903,10 @@ export function sqliteEngine(options: SqliteEngineOptions): SqliteQueryEngine {
     const limit = normalizeLimit(params.limit);
 
     if (limit === 0) {
-      return { documents: [], cursor: null };
+      return withQueryDiagnostics(
+        { documents: [], cursor: null },
+        queryDiagnosticsForIndexedQuery(params),
+      );
     }
 
     const index = params.index!;
@@ -957,7 +971,10 @@ export function sqliteEngine(options: SqliteEngineOptions): SqliteQueryEngine {
 
     const rows = db.prepare(sql).all(...args, fetchLimit) as QueryRow[];
 
-    return formatPage(rows, params, collection, includeWriteTokens);
+    return withQueryDiagnostics(
+      formatPage(rows, params, collection, includeWriteTokens),
+      queryDiagnosticsForIndexedQuery(params),
+    );
   }
 
   function formatPage(

--- a/tests/integration/conformance-suite.ts
+++ b/tests/integration/conformance-suite.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { EngineUniqueConstraintError, type QueryEngine } from "../../src/engines/types";
+import {
+  EngineUniqueConstraintError,
+  type EngineQueryDiagnostics,
+  type QueryEngine,
+} from "../../src/engines/types";
 import { expectRejectInstanceOf } from "./helpers";
 
 interface DecodedQueryCursorPayload {
@@ -24,6 +28,24 @@ interface QueryEngineConformanceSuiteOptions<TOptions = Record<string, unknown>>
 
 function decodeQueryCursor(cursor: string): DecodedQueryCursorPayload {
   return JSON.parse(Buffer.from(cursor, "base64url").toString("utf8")) as DecodedQueryCursorPayload;
+}
+
+function expectIndexedQueryDiagnostics(
+  diagnostics: EngineQueryDiagnostics | undefined,
+  index: string,
+): void {
+  expect(diagnostics).toBeDefined();
+
+  if (!diagnostics) {
+    throw new Error("Expected indexed query diagnostics");
+  }
+
+  expect(["native_pushdown", "fallback_scan"]).toContain(diagnostics.mode);
+  expect(["native_pushdown", "unsupported_filter", "full_scan"]).toContain(diagnostics.reason);
+
+  if (diagnostics.reason !== "full_scan") {
+    expect(diagnostics.index).toBe(index);
+  }
 }
 
 export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown>>(
@@ -113,23 +135,24 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
       });
       const scanned = await engine.query(collection, {});
 
-      expect(indexed.diagnostics).toBeDefined();
-      const indexedDiagnostics = indexed.diagnostics;
-
-      if (!indexedDiagnostics) {
-        throw new Error("Expected indexed query diagnostics");
-      }
-
-      expect(["native_pushdown", "fallback_scan"]).toContain(indexedDiagnostics.mode);
-      expect(["native_pushdown", "unsupported_filter", "full_scan"]).toContain(
-        indexedDiagnostics.reason,
-      );
-
-      if (indexedDiagnostics.reason !== "full_scan") {
-        expect(indexedDiagnostics.index).toBe("status");
-      }
-
+      expectIndexedQueryDiagnostics(indexed.diagnostics, "status");
       expect(scanned.diagnostics).toEqual({
+        mode: "fallback_scan",
+        reason: "full_scan",
+      });
+
+      if (!engine.queryWithMetadata) {
+        return;
+      }
+
+      const indexedWithMetadata = await engine.queryWithMetadata(collection, {
+        index: "status",
+        filter: { value: "active" },
+      });
+      const scannedWithMetadata = await engine.queryWithMetadata(collection, {});
+
+      expectIndexedQueryDiagnostics(indexedWithMetadata.diagnostics, "status");
+      expect(scannedWithMetadata.diagnostics).toEqual({
         mode: "fallback_scan",
         reason: "full_scan",
       });

--- a/tests/integration/conformance-suite.ts
+++ b/tests/integration/conformance-suite.ts
@@ -98,6 +98,43 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
       expect(scanResults.documents.map((entry) => entry.key).sort()).toEqual(["u1", "u2", "u3"]);
     });
 
+    test("emits diagnostics for indexed queries and collection scans", async () => {
+      const engine = getEngine();
+      const collection = nextCollection("diagnostic_users");
+
+      await engine.batchSet(collection, [
+        { key: "u1", doc: { id: "u1", status: "active" }, indexes: { status: "active" } },
+        { key: "u2", doc: { id: "u2", status: "inactive" }, indexes: { status: "inactive" } },
+      ]);
+
+      const indexed = await engine.query(collection, {
+        index: "status",
+        filter: { value: "active" },
+      });
+      const scanned = await engine.query(collection, {});
+
+      expect(indexed.diagnostics).toBeDefined();
+      const indexedDiagnostics = indexed.diagnostics;
+
+      if (!indexedDiagnostics) {
+        throw new Error("Expected indexed query diagnostics");
+      }
+
+      expect(["native_pushdown", "fallback_scan"]).toContain(indexedDiagnostics.mode);
+      expect(["native_pushdown", "unsupported_filter", "full_scan"]).toContain(
+        indexedDiagnostics.reason,
+      );
+
+      if (indexedDiagnostics.reason !== "full_scan") {
+        expect(indexedDiagnostics.index).toBe("status");
+      }
+
+      expect(scanned.diagnostics).toEqual({
+        mode: "fallback_scan",
+        reason: "full_scan",
+      });
+    });
+
     test("uses shared sorting and cursor pagination semantics", async () => {
       const engine = getEngine();
       const sortedCollection = nextCollection("items");

--- a/tests/integration/conformance-suite.ts
+++ b/tests/integration/conformance-suite.ts
@@ -133,9 +133,15 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
         index: "status",
         filter: { value: "active" },
       });
+      const emptyIndexed = await engine.query(collection, {
+        index: "status",
+        filter: { value: "missing" },
+      });
       const scanned = await engine.query(collection, {});
 
       expectIndexedQueryDiagnostics(indexed.diagnostics, "status");
+      expect(emptyIndexed.documents).toEqual([]);
+      expectIndexedQueryDiagnostics(emptyIndexed.diagnostics, "status");
       expect(scanned.diagnostics).toEqual({
         mode: "fallback_scan",
         reason: "full_scan",
@@ -149,9 +155,15 @@ export function runQueryEngineConformanceSuite<TOptions = Record<string, unknown
         index: "status",
         filter: { value: "active" },
       });
+      const emptyIndexedWithMetadata = await engine.queryWithMetadata(collection, {
+        index: "status",
+        filter: { value: "missing" },
+      });
       const scannedWithMetadata = await engine.queryWithMetadata(collection, {});
 
       expectIndexedQueryDiagnostics(indexedWithMetadata.diagnostics, "status");
+      expect(emptyIndexedWithMetadata.documents).toEqual([]);
+      expectIndexedQueryDiagnostics(emptyIndexedWithMetadata.diagnostics, "status");
       expect(scannedWithMetadata.diagnostics).toEqual({
         mode: "fallback_scan",
         reason: "full_scan",

--- a/tests/integration/indexeddb-engine.test.ts
+++ b/tests/integration/indexeddb-engine.test.ts
@@ -970,7 +970,7 @@ describe("indexedDbEngine query behavior", () => {
       expect(results.documents.map((item) => item.key).sort()).toEqual(["a", "b"]);
       expect(results.diagnostics).toEqual({
         mode: "fallback_scan",
-        reason: "fallback_scan",
+        reason: "unsupported_filter",
         index: "byRole",
       });
     } finally {


### PR DESCRIPTION
## Summary

Closes #181.

This PR makes query diagnostics consistent across bundled adapters so consumers can observe native query pushdown, fallback scans, and full collection scans through `queryDiagnostics.onQueryDiagnostic`.

## Changes

- Added shared engine diagnostic helpers for native indexed queries, full collection scans, unsupported-filter fallbacks, and result wrapping.
- Attached diagnostics to SQL adapter query paths (`sqlite`, `mysql`, `postgres`) for both index queries and collection scans, including limit-zero branches.
- Attached diagnostics to non-SQL adapters that previously omitted them (`dynamodb`, `firestore`, `redis`, `cassandra`) and normalized IndexedDB collection-scan fallback diagnostics to `full_scan`.
- Added conformance coverage asserting every adapter reports diagnostics for indexed queries and collection scans.
- Documented query diagnostics monitoring in the README.
- Added a changeset for the new observable diagnostics behavior.

## Verification

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun run test`
- `bun run test:integration:memory`
- `bun run test:integration:sqlite`
- `bun run test:integration:indexeddb`

External-service integration suites were not run locally because they require service containers.