### PR TITLE
[codex] Add native Cassandra indexed queries

### DIFF
--- a/.changeset/cassandra-native-indexed-queries.md
+++ b/.changeset/cassandra-native-indexed-queries.md
@@ -1,0 +1,5 @@
+---
+"nosql-odm": minor
+---
+
+Add native Cassandra indexed query execution backed by a query index table, including index maintenance on writes and deletes plus stable opaque cursor pagination.

--- a/src/engines/cassandra.ts
+++ b/src/engines/cassandra.ts
@@ -1,7 +1,16 @@
 import { DefaultMigrator } from "../migrator";
 import { getPreparedSerializedDocument, prepareDocumentForStorage } from "./document-preparation";
-import { encodeQueryPageCursor, resolveQueryPageStartIndex } from "./query-cursor";
-import { queryDiagnosticsForCollectionScan, withQueryDiagnostics } from "./query-diagnostics";
+import {
+  encodeQueryPageCursor,
+  resolveQueryPageCursorPosition,
+  resolveQueryPageStartIndex,
+} from "./query-cursor";
+import {
+  queryDiagnosticsForCollectionScan,
+  queryDiagnosticsForIndexedQuery,
+  queryDiagnosticsForUnsupportedFilter,
+  withQueryDiagnostics,
+} from "./query-diagnostics";
 import {
   type BatchSetItem,
   type BatchSetResult,
@@ -21,6 +30,7 @@ import {
 } from "./types";
 
 const DEFAULT_DOCUMENTS_TABLE = "nosql_odm_documents";
+const DEFAULT_INDEXES_TABLE = "nosql_odm_indexes";
 const DEFAULT_METADATA_TABLE = "nosql_odm_metadata";
 const DEFAULT_MIGRATION_INDEX_TABLE = "nosql_odm_migration_index";
 const OUTDATED_PAGE_LIMIT = 100;
@@ -56,6 +66,7 @@ export interface CassandraEngineOptions {
   client: CassandraClientLike;
   keyspace: string;
   documentsTable?: string;
+  indexesTable?: string;
   metadataTable?: string;
   migrationIndexTable?: string;
 }
@@ -92,6 +103,12 @@ interface MigrationIndexRow {
   indexSignatureSort: string;
 }
 
+interface QueryIndexRow {
+  key: string;
+  createdAt: number;
+  indexValue: string;
+}
+
 type OutdatedCursorPhase = "stale-low" | "stale-current" | "current-low" | "current-high";
 
 interface OutdatedCursorState {
@@ -108,6 +125,11 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
     options.documentsTable ?? DEFAULT_DOCUMENTS_TABLE,
     "documentsTable",
   );
+  const indexesTable = qualifyTableName(
+    options.keyspace,
+    options.indexesTable ?? DEFAULT_INDEXES_TABLE,
+    "indexesTable",
+  );
   const metadataTable = qualifyTableName(
     options.keyspace,
     options.metadataTable ?? DEFAULT_METADATA_TABLE,
@@ -119,7 +141,13 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
     "migrationIndexTable",
   );
 
-  const ready = ensureSchema(client, documentsTable, metadataTable, migrationIndexTable);
+  const ready = ensureSchema(
+    client,
+    documentsTable,
+    indexesTable,
+    metadataTable,
+    migrationIndexTable,
+  );
   let lastCreatedAt = 0;
 
   function nextCreatedAt(): number {
@@ -185,6 +213,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       const created = await createDocumentWithMetadata(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         payload,
       );
@@ -200,6 +229,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       await putDocumentWithMetadata(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         collection,
         key,
@@ -216,6 +246,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       const updated = await updateDocumentWithMetadata(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         collection,
         key,
@@ -235,6 +266,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       await deleteDocumentAndMigrationIndex(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         collection,
         key,
@@ -244,24 +276,47 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
     async query(collection, params) {
       await ready;
 
+      const indexed = await queryByIndex(client, indexesTable, documentsTable, collection, params);
+
+      if (indexed) {
+        return indexed;
+      }
+
       const rows = await listCollectionDocuments(client, documentsTable, collection);
       const matched = matchDocuments(rows, params);
 
       return withQueryDiagnostics(
         paginate(collection, matched, params),
-        queryDiagnosticsForCollectionScan(),
+        params.index
+          ? queryDiagnosticsForUnsupportedFilter(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 
     async queryWithMetadata(collection, params) {
       await ready;
 
+      const indexed = await queryByIndex(
+        client,
+        indexesTable,
+        documentsTable,
+        collection,
+        params,
+        true,
+      );
+
+      if (indexed) {
+        return indexed;
+      }
+
       const rows = await listCollectionDocuments(client, documentsTable, collection);
       const matched = matchDocuments(rows, params);
 
       return withQueryDiagnostics(
         paginateWithWriteTokens(collection, matched, params),
-        queryDiagnosticsForCollectionScan(),
+        params.index
+          ? queryDiagnosticsForUnsupportedFilter(params)
+          : queryDiagnosticsForCollectionScan(),
       );
     },
 
@@ -314,6 +369,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
         await putDocumentWithMetadata(
           client,
           documentsTable,
+          indexesTable,
           migrationIndexTable,
           collection,
           item.key,
@@ -331,6 +387,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
       return batchSetDocumentsWithResult(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         collection,
         items,
@@ -345,6 +402,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
         await deleteDocumentAndMigrationIndex(
           client,
           documentsTable,
+          indexesTable,
           migrationIndexTable,
           collection,
           key,
@@ -505,6 +563,7 @@ export function cassandraEngine(options: CassandraEngineOptions): CassandraQuery
 async function ensureSchema(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   metadataTable: string,
   migrationIndexTable: string,
 ): Promise<void> {
@@ -530,6 +589,18 @@ async function ensureSchema(
   await ensureColumn(client, documentsTable, "migration_version_state", "text");
   await ensureColumn(client, documentsTable, "migration_index_signature", "text");
   await ensureColumn(client, documentsTable, "migration_index_signature_sort", "text");
+
+  await execute(
+    client,
+    `CREATE TABLE IF NOT EXISTS ${indexesTable} (
+      collection text,
+      index_name text,
+      index_value text,
+      created_at bigint,
+      doc_key text,
+      PRIMARY KEY ((collection, index_name), index_value, created_at, doc_key)
+    )`,
+  );
 
   await execute(
     client,
@@ -579,6 +650,189 @@ async function listCollectionDocuments(
   });
 
   return parsed;
+}
+
+async function queryByIndex(
+  client: CassandraClientLike,
+  indexesTable: string,
+  documentsTable: string,
+  collection: string,
+  params: QueryParams,
+  includeWriteTokens = false,
+): Promise<EngineQueryResult | null> {
+  if (!params.index || !params.filter) {
+    return null;
+  }
+
+  const normalizedLimit = normalizeLimit(params.limit);
+
+  if (normalizedLimit === 0) {
+    return withQueryDiagnostics(
+      {
+        documents: [],
+        cursor: null,
+      },
+      queryDiagnosticsForIndexedQuery(params),
+    );
+  }
+
+  const query = buildIndexQuery(indexesTable, collection, params);
+
+  if (!query) {
+    return null;
+  }
+
+  const rows = await execute(client, query.cql, query.params, true);
+  const indexRows = rows.map(parseQueryIndexRow);
+  const docs = await batchGetDocuments(
+    client,
+    documentsTable,
+    collection,
+    indexRows.map((row) => row.key),
+  );
+  const joined: StoredDocumentRow[] = [];
+
+  for (const indexRow of indexRows) {
+    const doc = docs.get(indexRow.key);
+
+    if (
+      !doc ||
+      doc.createdAt !== indexRow.createdAt ||
+      doc.indexes[params.index] !== indexRow.indexValue
+    ) {
+      continue;
+    }
+
+    joined.push(doc);
+  }
+
+  return withQueryDiagnostics(
+    includeWriteTokens
+      ? paginateWithWriteTokens(collection, joined, params)
+      : paginate(collection, joined, params),
+    queryDiagnosticsForIndexedQuery(params),
+  );
+}
+
+function buildIndexQuery(
+  indexesTable: string,
+  collection: string,
+  params: QueryParams,
+): { cql: string; params: unknown[] } | null {
+  const filter = params.filter?.value;
+  const bounds = buildIndexValueBounds(filter);
+
+  if (!bounds) {
+    return null;
+  }
+
+  if (params.sort === "desc" || (bounds.eq === undefined && params.sort !== "asc")) {
+    return null;
+  }
+
+  resolveQueryPageCursorPosition(collection, params);
+  const clauses = ["collection = ?", "index_name = ?"];
+  const values: unknown[] = [collection, params.index!];
+
+  if (bounds.eq !== undefined) {
+    clauses.push("index_value = ?");
+    values.push(bounds.eq);
+  } else {
+    if (bounds.lower !== undefined) {
+      clauses.push(`index_value ${bounds.lowerInclusive ? ">=" : ">"} ?`);
+      values.push(bounds.lower);
+    }
+
+    if (bounds.upper !== undefined) {
+      clauses.push(`index_value ${bounds.upperInclusive ? "<=" : "<"} ?`);
+      values.push(bounds.upper);
+    }
+  }
+
+  const orderBy =
+    params.sort === "asc" ? " ORDER BY index_value ASC, created_at ASC, doc_key ASC" : "";
+
+  return {
+    cql: `SELECT doc_key, created_at, index_value FROM ${indexesTable} WHERE ${clauses.join(" AND ")}${orderBy}`,
+    params: values,
+  };
+}
+
+interface IndexValueBounds {
+  eq?: string;
+  lower?: string;
+  lowerInclusive: boolean;
+  upper?: string;
+  upperInclusive: boolean;
+}
+
+function buildIndexValueBounds(
+  filter: NonNullable<QueryParams["filter"]>["value"] | undefined,
+): IndexValueBounds | null {
+  if (typeof filter === "string" || typeof filter === "number") {
+    return {
+      eq: String(filter),
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+  }
+
+  if (!filter) {
+    return null;
+  }
+
+  if (filter.$eq !== undefined) {
+    return {
+      eq: String(filter.$eq as string | number),
+      lowerInclusive: true,
+      upperInclusive: true,
+    };
+  }
+
+  if (filter.$begins !== undefined) {
+    return {
+      lower: filter.$begins,
+      lowerInclusive: true,
+      upper: `${filter.$begins}\u{10ffff}`,
+      upperInclusive: true,
+    };
+  }
+
+  if (filter.$between !== undefined) {
+    const [low, high] = filter.$between as [string | number, string | number];
+
+    return {
+      lower: String(low),
+      lowerInclusive: true,
+      upper: String(high),
+      upperInclusive: true,
+    };
+  }
+
+  return {
+    lower:
+      filter.$gt !== undefined
+        ? String(filter.$gt as string | number)
+        : filter.$gte !== undefined
+          ? String(filter.$gte as string | number)
+          : undefined,
+    lowerInclusive: filter.$gte !== undefined,
+    upper:
+      filter.$lt !== undefined
+        ? String(filter.$lt as string | number)
+        : filter.$lte !== undefined
+          ? String(filter.$lte as string | number)
+          : undefined,
+    upperInclusive: filter.$lte !== undefined,
+  };
+}
+
+function parseQueryIndexRow(row: CassandraRowLike): QueryIndexRow {
+  return {
+    key: readStringColumn(row, "doc_key", "query index row"),
+    createdAt: readFiniteNumberColumn(row, "created_at", "query index row"),
+    indexValue: readStringColumn(row, "index_value", "query index row"),
+  };
 }
 
 async function getDocumentRow(
@@ -1089,6 +1343,7 @@ function toDocumentWritePayload(
 async function putDocumentWithMetadata(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   collection: string,
   key: string,
@@ -1113,6 +1368,7 @@ async function putDocumentWithMetadata(
       const created = await createDocumentWithMetadata(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         payload,
       );
@@ -1136,6 +1392,7 @@ async function putDocumentWithMetadata(
     const applied = await updateDocumentAndMigrationIndexConditionally(
       client,
       documentsTable,
+      indexesTable,
       migrationIndexTable,
       payload,
       existing.writeVersion,
@@ -1144,6 +1401,7 @@ async function putDocumentWithMetadata(
         versionState: existing.migrationVersionState,
         indexSignatureSort: existing.migrationIndexSignatureSort,
       },
+      existing,
     );
 
     if (applied) {
@@ -1157,6 +1415,7 @@ async function putDocumentWithMetadata(
 async function createDocumentWithMetadata(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   payload: DocumentWritePayload,
 ): Promise<boolean> {
@@ -1202,12 +1461,14 @@ async function createDocumentWithMetadata(
     payload.writeVersion,
     undefined,
   );
+  await replaceQueryIndexRows(client, indexesTable, payload, undefined);
   return true;
 }
 
 async function updateDocumentWithMetadata(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   collection: string,
   key: string,
@@ -1234,6 +1495,7 @@ async function updateDocumentWithMetadata(
     const applied = await updateDocumentAndMigrationIndexConditionally(
       client,
       documentsTable,
+      indexesTable,
       migrationIndexTable,
       payload,
       existing.writeVersion,
@@ -1242,6 +1504,7 @@ async function updateDocumentWithMetadata(
         versionState: existing.migrationVersionState,
         indexSignatureSort: existing.migrationIndexSignatureSort,
       },
+      existing,
     );
 
     if (applied) {
@@ -1255,6 +1518,7 @@ async function updateDocumentWithMetadata(
 async function updateDocumentAndMigrationIndexConditionally(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   payload: DocumentWritePayload,
   expectedWriteVersion: number,
@@ -1263,6 +1527,7 @@ async function updateDocumentAndMigrationIndexConditionally(
     versionState: MigrationVersionState;
     indexSignatureSort: string;
   },
+  previousQueryIndexes: StoredDocumentRow,
 ): Promise<boolean> {
   const rows = await execute(
     client,
@@ -1307,6 +1572,7 @@ async function updateDocumentAndMigrationIndexConditionally(
     payload.writeVersion,
     previousIndex,
   );
+  await replaceQueryIndexRows(client, indexesTable, payload, previousQueryIndexes);
   return true;
 }
 
@@ -1451,6 +1717,7 @@ async function upsertMigrationIndexRow(
 async function deleteDocumentAndMigrationIndex(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   collection: string,
   key: string,
@@ -1487,11 +1754,50 @@ async function deleteDocumentAndMigrationIndex(
     ],
     true,
   );
+  await deleteQueryIndexRows(client, indexesTable, collection, key, existing);
+}
+
+async function replaceQueryIndexRows(
+  client: CassandraClientLike,
+  indexesTable: string,
+  payload: DocumentWritePayload,
+  previous: StoredDocumentRow | undefined,
+): Promise<void> {
+  if (previous) {
+    await deleteQueryIndexRows(client, indexesTable, payload.collection, payload.key, previous);
+  }
+
+  for (const [indexName, indexValue] of Object.entries(payload.indexes)) {
+    await execute(
+      client,
+      `INSERT INTO ${indexesTable} (collection, index_name, index_value, created_at, doc_key) VALUES (?, ?, ?, ?, ?)`,
+      [payload.collection, indexName, indexValue, payload.createdAt, payload.key],
+      true,
+    );
+  }
+}
+
+async function deleteQueryIndexRows(
+  client: CassandraClientLike,
+  indexesTable: string,
+  collection: string,
+  key: string,
+  row: StoredDocumentRow,
+): Promise<void> {
+  for (const [indexName, indexValue] of Object.entries(row.indexes)) {
+    await execute(
+      client,
+      `DELETE FROM ${indexesTable} WHERE collection = ? AND index_name = ? AND index_value = ? AND created_at = ? AND doc_key = ?`,
+      [collection, indexName, indexValue, row.createdAt, key],
+      true,
+    );
+  }
 }
 
 async function batchSetDocumentsWithResult(
   client: CassandraClientLike,
   documentsTable: string,
+  indexesTable: string,
   migrationIndexTable: string,
   collection: string,
   items: BatchSetItem[],
@@ -1508,6 +1814,7 @@ async function batchSetDocumentsWithResult(
       await putDocumentWithMetadata(
         client,
         documentsTable,
+        indexesTable,
         migrationIndexTable,
         collection,
         item.key,
@@ -1539,6 +1846,7 @@ async function batchSetDocumentsWithResult(
     const applied = await updateDocumentAndMigrationIndexConditionally(
       client,
       documentsTable,
+      indexesTable,
       migrationIndexTable,
       payload,
       expectedWriteVersion,
@@ -1547,6 +1855,7 @@ async function batchSetDocumentsWithResult(
         versionState: existing.migrationVersionState,
         indexSignatureSort: existing.migrationIndexSignatureSort,
       },
+      existing,
     );
 
     if (!applied) {

--- a/tests/integration/cassandra-engine.test.ts
+++ b/tests/integration/cassandra-engine.test.ts
@@ -477,6 +477,49 @@ describe("cassandraEngine integration", () => {
     expect(scan.documents).toHaveLength(3);
   });
 
+  test("indexed equality queries use native Cassandra pushdown diagnostics", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byEmail: "sam@example.com" });
+    await engine.put(collection, "u2", { id: "u2" }, { byEmail: "jamie@example.com" });
+
+    const result = await engine.query(collection, {
+      index: "byEmail",
+      filter: { value: "sam@example.com" },
+    });
+
+    expect(result.documents.map((item) => item.key)).toEqual(["u1"]);
+    expect(result.diagnostics).toEqual({
+      mode: "native_pushdown",
+      reason: "native_pushdown",
+      index: "byEmail",
+    });
+  });
+
+  test("indexed pagination remains stable when the cursor row is deleted", async () => {
+    await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
+    await engine.put(collection, "u2", { id: "u2" }, { byRole: "member#b" });
+    await engine.put(collection, "u3", { id: "u3" }, { byRole: "member#c" });
+
+    const first = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      limit: 1,
+    });
+
+    await engine.delete(collection, "u1");
+
+    const second = await engine.query(collection, {
+      index: "byRole",
+      filter: { value: { $begins: "member#" } },
+      sort: "asc",
+      cursor: first.cursor ?? undefined,
+      limit: 2,
+    });
+
+    expect(first.documents.map((item) => item.key)).toEqual(["u1"]);
+    expect(second.documents.map((item) => item.key)).toEqual(["u2", "u3"]);
+  });
+
   test("query pagination edge cases", async () => {
     await engine.put(collection, "u1", { id: "u1" }, { byRole: "member#a" });
     await engine.put(collection, "u2", { id: "u2" }, { byRole: "member#b" });

--- a/tests/unit/cassandra-engine.test.ts
+++ b/tests/unit/cassandra-engine.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import { cassandraEngine } from "../../src/engines/cassandra";
 
+interface CapturedQuery {
+  readonly query: string;
+  readonly params?: readonly unknown[];
+}
+
 describe("cassandraEngine", () => {
   test('reports uniqueConstraints capability as "none"', () => {
     const engine = cassandraEngine({
@@ -14,5 +19,141 @@ describe("cassandraEngine", () => {
     });
 
     expect(engine.capabilities?.uniqueConstraints).toBe("none");
+  });
+
+  test("uses query index table for indexed equality queries", async () => {
+    const captured: CapturedQuery[] = [];
+    const engine = cassandraEngine({
+      client: {
+        async execute(query, params) {
+          captured.push({ query, params });
+
+          if (query.includes("IF NOT EXISTS")) {
+            return { rows: [{ "[applied]": true }] };
+          }
+
+          if (query.includes("SELECT doc_key") && query.includes("nosql_odm_indexes")) {
+            return {
+              rows: [{ doc_key: "u1", created_at: 1, index_value: "sam@example.com" }],
+            };
+          }
+
+          if (query.includes("doc_key IN")) {
+            return {
+              rows: [
+                {
+                  doc_key: "u1",
+                  created_at: 1,
+                  write_version: 1,
+                  doc: JSON.stringify({ id: "u1", email: "sam@example.com" }),
+                  indexes: { byEmail: "sam@example.com" },
+                  migration_target_version: 0,
+                  migration_version_state: "unknown",
+                  migration_index_signature: null,
+                  migration_index_signature_sort: "",
+                },
+              ],
+            };
+          }
+
+          return { rows: [] };
+        },
+      },
+      keyspace: "test_keyspace",
+    });
+
+    const result = await engine.query("users", {
+      index: "byEmail",
+      filter: { value: "sam@example.com" },
+    });
+
+    expect(result.documents).toEqual([{ key: "u1", doc: { id: "u1", email: "sam@example.com" } }]);
+    expect(result.diagnostics).toEqual({
+      mode: "native_pushdown",
+      reason: "native_pushdown",
+      index: "byEmail",
+    });
+    expect(
+      captured.some(
+        (item) =>
+          item.query.includes("FROM test_keyspace.nosql_odm_documents WHERE collection = ?") &&
+          !item.query.includes("doc_key"),
+      ),
+    ).toBe(false);
+  });
+
+  test("maintains query index rows on create, update, and delete", async () => {
+    const captured: CapturedQuery[] = [];
+    const stored = new Map<string, Record<string, unknown>>();
+
+    const engine = cassandraEngine({
+      client: {
+        async execute(query, params) {
+          captured.push({ query, params });
+
+          if (query.includes("SELECT doc_key") && query.includes("doc_key = ?")) {
+            const row = stored.get(String(params?.[1]));
+            return { rows: row ? [row] : [] };
+          }
+
+          if (query.includes("IF NOT EXISTS")) {
+            stored.set(String(params?.[1]), {
+              doc_key: params?.[1],
+              created_at: params?.[2],
+              write_version: params?.[3],
+              doc: params?.[4],
+              indexes: params?.[5],
+              migration_target_version: params?.[6],
+              migration_version_state: params?.[7],
+              migration_index_signature: params?.[8],
+              migration_index_signature_sort: params?.[9],
+            });
+            return { rows: [{ "[applied]": true }] };
+          }
+
+          if (query.startsWith("UPDATE test_keyspace.nosql_odm_documents")) {
+            stored.set(String(params?.[9]), {
+              doc_key: params?.[9],
+              created_at: params?.[0],
+              write_version: params?.[1],
+              doc: params?.[2],
+              indexes: params?.[3],
+              migration_target_version: params?.[4],
+              migration_version_state: params?.[5],
+              migration_index_signature: params?.[6],
+              migration_index_signature_sort: params?.[7],
+            });
+            return { rows: [{ "[applied]": true }] };
+          }
+
+          return { rows: [] };
+        },
+      },
+      keyspace: "test_keyspace",
+    });
+
+    await engine.create("users", "u1", { id: "u1" }, { byEmail: "old@example.com" });
+    await engine.update("users", "u1", { id: "u1" }, { byEmail: "new@example.com" });
+    await engine.delete("users", "u1");
+
+    const indexInserts = captured.filter(
+      (item) =>
+        item.query.includes("INSERT INTO test_keyspace.nosql_odm_indexes") &&
+        item.params?.[1] === "byEmail",
+    );
+    const indexDeletes = captured.filter(
+      (item) =>
+        item.query.includes("DELETE FROM test_keyspace.nosql_odm_indexes") &&
+        item.params?.[1] === "byEmail",
+    );
+
+    expect(indexInserts.map((item) => item.params?.[2])).toEqual([
+      "old@example.com",
+      "new@example.com",
+    ]);
+    expect(indexDeletes.map((item) => item.params?.[2])).toEqual([
+      "old@example.com",
+      "new@example.com",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #182.

This adds a dedicated Cassandra query index table keyed by collection, index name, index value, created timestamp, and document key. Cassandra now maintains those query index rows during create, put, update, batchSet, conditional batchSet writeback, delete, and batchDelete paths.

Supported indexed query shapes now use native Cassandra index-table reads instead of loading every document in the collection. Unsupported Cassandra access patterns, such as descending sorted indexed queries, continue through the existing collection-scan fallback and report fallback diagnostics.

## Impact

Indexed equality queries no longer perform full collection document loads. Ascending range and prefix queries use the query index table, then hydrate only matching document keys. Cursor pagination remains opaque and can resume when the cursor row has been deleted.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`
- `bun run services:up:cassandra && bun run test:integration:cassandra && bun run services:down:cassandra`